### PR TITLE
feat: filter by viewport

### DIFF
--- a/frontend/app/components/map.tsx
+++ b/frontend/app/components/map.tsx
@@ -1,18 +1,18 @@
-import { useEffect, useRef } from 'react';
-import {
-  Map,
-  GeoJSONSource,
-  LngLatBoundsLike,
-  RasterTileSource,
-  Marker,
-  LngLatBounds
-} from 'maplibre-gl';
-import 'maplibre-gl/dist/maplibre-gl.css';
 import { RASTER_API_PATH, useStacItems } from '$hooks/useStacCatalog';
 import { Feature, FeatureCollection, Geometry } from 'geojson';
+import {
+  GeoJSONSource,
+  LngLatBounds,
+  LngLatBoundsLike,
+  Map,
+  Marker,
+  RasterTileSource
+} from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { useEffect, useRef } from 'react';
 import { StacItem } from 'stac-ts';
-import { StacFeatureCollection } from '../types/stac';
 import { useStac } from '../context/StacContext';
+import { StacFeatureCollection } from '../types/stac';
 
 interface MapComponentProps {
   centerCoordinates?: [number, number];
@@ -29,13 +29,20 @@ export default function MapComponent({
   zoom = 1,
   onSelect
 }: MapComponentProps) {
-  const { selectedItem, selectedCollection, filters, setSelectedItem } =
-    useStac();
+  const {
+    selectedItem,
+    selectedCollection,
+    filters,
+    setSelectedItem,
+    setBbox,
+    bbox
+  } = useStac();
   const map = useRef<Map | null>(null);
   const markersRef = useRef<Marker[]>([]);
   const { data: stacItems, isLoading } = useStacItems(
     selectedCollection,
-    filters
+    filters,
+    bbox
   );
 
   useEffect(() => {
@@ -132,6 +139,13 @@ export default function MapComponent({
           map.current?.on('mouseleave', 'stac-items-layer', () => {
             if (map.current) {
               map.current.getCanvas().style.cursor = '';
+            }
+          });
+
+          map.current?.on('moveend', () => {
+            if (map.current) {
+              const bounds = map.current.getBounds();
+              setBbox(bounds.toArray().flat());
             }
           });
         }

--- a/frontend/app/context/StacContext.tsx
+++ b/frontend/app/context/StacContext.tsx
@@ -1,11 +1,11 @@
-import { createContext, useContext, useState, ReactNode } from 'react';
+import { createContext, ReactNode, useContext, useState } from 'react';
 import { StacCollection } from 'stac-ts';
-import { StacFeatureCollection, StacQueryables } from '../types/stac';
 import {
   useStacCollections,
   useStacItems,
   useStacQueryables
 } from '../hooks/useStacCatalog';
+import { StacFeatureCollection, StacQueryables } from '../types/stac';
 
 export interface DateFilter {
   startDate: string | undefined;
@@ -41,6 +41,9 @@ interface StacContextType {
 
   stacQueryables?: StacQueryables;
   filters: StacItemFilter;
+
+  bbox: number[];
+  setBbox: (bbox: number[]) => void;
 }
 
 const StacContext = createContext<StacContextType | undefined>(undefined);
@@ -64,6 +67,7 @@ export function StacProvider({ children }: StacProviderProps) {
     itemIdFilter: { itemId: undefined },
     dateFilter: { startDate: undefined, endDate: undefined }
   });
+  const [bbox, setBbox] = useState<number[]>([-180, -90, 180, 90]);
 
   const {
     data: stacCollections,
@@ -75,7 +79,7 @@ export function StacProvider({ children }: StacProviderProps) {
     data: stacItems,
     isLoading: isStacItemsLoading,
     error: isStacItemsError
-  } = useStacItems(selectedCollection, filters);
+  } = useStacItems(selectedCollection, filters, bbox);
 
   const {
     data: stacQueryables,
@@ -113,7 +117,10 @@ export function StacProvider({ children }: StacProviderProps) {
     handleSelectCollection,
     handleSelectQueryable,
     handleSetFilter,
-    setSelectedItem
+    setSelectedItem,
+
+    bbox,
+    setBbox
   };
 
   return <StacContext.Provider value={value}>{children}</StacContext.Provider>;

--- a/frontend/app/hooks/useStacCatalog.ts
+++ b/frontend/app/hooks/useStacCatalog.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { type StacCatalog, type StacCollection } from 'stac-ts';
-import { StacFeatureCollection, StacQueryables } from '../types/stac';
 import { StacItemFilter } from '../context/StacContext';
+import { StacFeatureCollection, StacQueryables } from '../types/stac';
 
 const STAC_API = import.meta.env.VITE_STAC_API_URL;
 const STAC_PATH = import.meta.env.VITE_STAC_API_PATHNAME;
@@ -45,12 +45,13 @@ export function useStacCollections() {
  */
 export function useStacItems(
   collection: string | undefined,
-  filters: StacItemFilter
+  filters: StacItemFilter,
+  bbox: number[]
 ) {
   return useQuery<StacFeatureCollection>({
-    queryKey: ['stacItems', collection, filters],
+    queryKey: ['stacItems', collection, filters, bbox],
     queryFn: async () => {
-      let stacItemsFetchURL = `${STAC_API_PATH}/collections/${collection}/items?limit=${STAC_ITEMS_LIMIT}`;
+      let stacItemsFetchURL = `${STAC_API_PATH}/collections/${collection}/items?limit=${STAC_ITEMS_LIMIT}&bbox=${bbox.join(',')}`;
       if (
         filters.dateFilter &&
         filters.dateFilter.startDate &&

--- a/frontend/app/hooks/useStacCatalog.ts
+++ b/frontend/app/hooks/useStacCatalog.ts
@@ -51,7 +51,7 @@ export function useStacItems(
   return useQuery<StacFeatureCollection>({
     queryKey: ['stacItems', collection, filters, bbox],
     queryFn: async () => {
-      let stacItemsFetchURL = `${STAC_API_PATH}/collections/${collection}/items?limit=${STAC_ITEMS_LIMIT}&bbox=${bbox.join(',')}`;
+      let stacItemsFetchURL = `${STAC_API_PATH}/collections/${collection}/items?limit=${STAC_ITEMS_LIMIT}&bbox=${bbox.join(',')}&sortby=-datetime`;
       if (
         filters.dateFilter &&
         filters.dateFilter.startDate &&

--- a/frontend/app/main.tsx
+++ b/frontend/app/main.tsx
@@ -4,8 +4,7 @@ setBasePath(
   'https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.20.1/cdn/'
 );
 
-import { useState } from 'react';
-import { createRoot } from 'react-dom/client';
+import Detail from '$components/detail';
 import {
   // useQuery,
   // useMutation,
@@ -13,10 +12,11 @@ import {
   QueryClient,
   QueryClientProvider
 } from '@tanstack/react-query';
+import { useState } from 'react';
+import { createRoot } from 'react-dom/client';
 import MapComponent from './components/map';
 import Sidebar from './components/sidebar';
 import { StacProvider } from './context/StacContext';
-import Detail from '$components/detail';
 
 // If using a router add the public url to the base path.
 // const publicUrl = process.env.BASE_URL || '';


### PR DESCRIPTION
Prototype of filtering the STAC query by the bbox of the viewport (aka zoom to a new spot, make a new query). Works ok, but it's a little awkard with the "zoom to clicked item" functionality and I wasn't sure how to handle that correctly?

I also added a `sortby=-datetime` to ensure consistent results.