### PR TITLE
Update temp STAC ds.io domain --> k8s.hotosm.org domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           VITE_APP_TITLE: OpenAerialMap
           VITE_APP_DESCRIPTION: set of tools for searching, sharing, and using openly licensed satellite and unmanned aerial vehicle (UAV) imagery
-          VITE_STAC_API_URL: https://hot-oam.ds.io/
+          VITE_STAC_API_URL: https://api.oam.hotosm.org/
           VITE_STAC_API_PATHNAME: stac
           VITE_STAC_TILER_PATHNAME: raster
           VITE_STAC_ITEMS_LIMIT: "40"

--- a/notebooks/titiler-pgstac.ipynb
+++ b/notebooks/titiler-pgstac.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "694c1218",
    "metadata": {},
    "outputs": [
@@ -43,7 +43,7 @@
     "import urllib.parse\n",
     "from pystac_client import Client\n",
     "\n",
-    "HOT_OAM_ROOT_URL = \"https://hot-oam.ds.io\"\n",
+    "HOT_OAM_ROOT_URL = \"https://api.oam.hotosm.org\"\n",
     "HOT_OAM_STAC_URL = urllib.parse.urljoin(HOT_OAM_ROOT_URL, \"stac\")\n",
     "client = Client.open(HOT_OAM_STAC_URL)\n",
     "print(\"Collections:\")\n",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- For testing / prototype, we used the STAC API hosted at `ds.io`.
- This PR updates the URLs in the repo --> `api.oam.hotosm.org` as the public facing domain for the new OAM API.
- Note that the internal domain used for k8s is `oam-eoapi-prod.imagery-services.k8s-prod.hotosm.org`, for which we have a CNAME `api.oam.hotosm.org` pointing to this.
- As a result, we will need to add both domains to the ingress config in the helm values in hotosm/k8s-infra repo.
- Just checking with @aliziel this is the correct approach?

## Checklist before requesting a review

- 📖 Read the OAM Contributing Guide: <https://github.com/hotosm/openaerialmap/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
