### PR TITLE
Update stactools to v0.2.1

### DIFF
--- a/backend/stac-ingester/pyproject.toml
+++ b/backend/stac-ingester/pyproject.toml
@@ -9,4 +9,4 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-stactools-hotosm = { git = "https://github.com/hotosm/stactools-hotosm", rev = "v0.2.0" }
+stactools-hotosm = { git = "https://github.com/hotosm/stactools-hotosm", rev = "v0.2.1" }

--- a/backend/stac-ingester/uv.lock
+++ b/backend/stac-ingester/uv.lock
@@ -145,7 +145,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "stactools-hotosm", extras = ["ingest"], git = "https://github.com/hotosm/stactools-hotosm?rev=v0.2.0" }]
+requires-dist = [{ name = "stactools-hotosm", extras = ["ingest"], git = "https://github.com/hotosm/stactools-hotosm?rev=v0.2.1" }]
 
 [[package]]
 name = "hydraters"
@@ -661,8 +661,8 @@ wheels = [
 
 [[package]]
 name = "stactools-hotosm"
-version = "0.2.0"
-source = { git = "https://github.com/hotosm/stactools-hotosm?rev=v0.2.0#64a3a40fc9e693a0b079e315342b8400097bdaf4" }
+version = "0.2.1"
+source = { git = "https://github.com/hotosm/stactools-hotosm?rev=v0.2.1#61eaeefe07666ba2c499ddf5de0f8b2e77547000" }
 dependencies = [
     { name = "pystac", extra = ["validation"] },
     { name = "requests" },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

updates to include fix here: https://github.com/hotosm/stactools-hotosm/pull/18

## Describe this PR

The maxar/vantor ingester was referencing the wrong events file. This fixes that issue. 

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the OAM Contributing Guide: <https://github.com/hotosm/openaerialmap/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
