### PR TITLE
fix(stactools-hotosm): skip metadata entries that fail STAC Item creation

### DIFF
--- a/backend/stactools-hotosm/src/stactools/hotosm/cli.py
+++ b/backend/stactools-hotosm/src/stactools/hotosm/cli.py
@@ -380,6 +380,7 @@ def sync_handler(
         except Exception as e:
             if handle_exceptions == "IGNORE":
                 errors.append(f"{raw_metadata_}: {e}")
+                continue
             else:
                 raise
         # NOTE: STAC Items cannot contain a Collection ID unless they also include

--- a/backend/stactools-hotosm/tests/test_cli.py
+++ b/backend/stactools-hotosm/tests/test_cli.py
@@ -1,0 +1,101 @@
+"""Tests for `stactools.hotosm.cli`."""
+
+import datetime as dt
+from typing import Iterator
+
+import pystac
+import pytest
+
+from stactools.hotosm.cli import sync_handler
+
+COLLECTION_ID = "test-collection"
+UPLOADED_AFTER = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+
+
+def _item(id_: str) -> pystac.Item:
+    """Build a minimal STAC Item for testing."""
+    return pystac.Item(
+        id=id_,
+        geometry={
+            "type": "Polygon",
+            "coordinates": [
+                [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+            ],
+        },
+        bbox=[0.0, 0.0, 1.0, 1.0],
+        datetime=UPLOADED_AFTER,
+        properties={},
+    )
+
+
+def _create_item(raw_metadata: str) -> pystac.Item:
+    """Create a STAC Item, failing for the entry named ``bad``."""
+    if raw_metadata == "bad":
+        raise ValueError("cannot create a STAC Item from this entry")
+    return _item(raw_metadata)
+
+
+def _middle_entry_fails(_uploaded_after: dt.datetime) -> Iterator[str]:
+    """Yield raw metadata whose second entry cannot be converted."""
+    yield from ["good-1", "bad", "good-2"]
+
+
+def _first_entry_fails(_uploaded_after: dt.datetime) -> Iterator[str]:
+    """Yield raw metadata whose first entry cannot be converted."""
+    yield from ["bad", "good-1"]
+
+
+class TestSyncHandler:
+    """Test the `sync_handler` orchestration helper."""
+
+    def test_ignored_failure_is_skipped(self):
+        """A failed entry is skipped rather than duplicating the previous Item."""
+        items, errors = sync_handler(
+            collection_id=COLLECTION_ID,
+            raw_metadata_creator=_middle_entry_fails,
+            stac_item_creator=_create_item,
+            uploaded_after=UPLOADED_AFTER,
+            handle_exceptions="IGNORE",
+        )
+
+        assert [item["id"] for item in items] == ["good-1", "good-2"]
+        assert all(item["collection"] == COLLECTION_ID for item in items)
+        assert len(errors) == 1
+
+    def test_ignored_failure_on_first_entry(self):
+        """A failure on the first entry is skipped without raising."""
+        items, errors = sync_handler(
+            collection_id=COLLECTION_ID,
+            raw_metadata_creator=_first_entry_fails,
+            stac_item_creator=_create_item,
+            uploaded_after=UPLOADED_AFTER,
+            handle_exceptions="IGNORE",
+        )
+
+        assert [item["id"] for item in items] == ["good-1"]
+        assert len(errors) == 1
+
+    def test_failure_is_raised_by_default(self):
+        """`RAISE` propagates the underlying exception."""
+        with pytest.raises(ValueError):
+            sync_handler(
+                collection_id=COLLECTION_ID,
+                raw_metadata_creator=_middle_entry_fails,
+                stac_item_creator=_create_item,
+                uploaded_after=UPLOADED_AFTER,
+                handle_exceptions="RAISE",
+            )
+
+    def test_all_entries_succeed(self):
+        """Every Item is collected and stamped with the Collection ID."""
+        items, errors = sync_handler(
+            collection_id=COLLECTION_ID,
+            raw_metadata_creator=lambda _: iter(["good-1", "good-2"]),
+            stac_item_creator=_create_item,
+            uploaded_after=UPLOADED_AFTER,
+            handle_exceptions="RAISE",
+        )
+
+        assert [item["id"] for item in items] == ["good-1", "good-2"]
+        assert all(item["collection"] == COLLECTION_ID for item in items)
+        assert errors == []


### PR DESCRIPTION
## Problem

`sync_handler` in `backend/stactools-hotosm/src/stactools/hotosm/cli.py` has no `continue` in the `except` branch, so control falls through to the lines that stamp the Collection ID and append the Item:

```python
try:
    item = stac_item_creator(raw_metadata_).to_dict()
except Exception as e:
    if handle_exceptions == "IGNORE":
        errors.append(f"{raw_metadata_}: {e}")
    else:
        raise
item["collection"] = collection_id
items.append(item)
```

With `--handle-exceptions=IGNORE`:

- if an entry fails, `item` still holds the **previous** entry's dict, so the failing entry is silently replaced by a duplicate of its predecessor;
- if the **first** entry fails, `item` is unbound and the run dies with `UnboundLocalError`.

This affects `dump_oam`, `dump_maxar`, `sync_oam` and `sync_maxar`, since they all go through `sync_handler`. `docs/dev/backend/stactools-hotosm.md` recommends `--handle-exceptions=IGNORE` for finishing a run when there are problems with the upstream data, which is exactly the bulk re-ingest path discussed in #247.

## Reproduction

Before the fix, the added tests fail with:

```text
AssertionError: assert ['good-1', 'good-1', 'good-2'] == ['good-1', 'good-2']

UnboundLocalError: cannot access local variable 'item' where it is not associated with a value
  src/stactools/hotosm/cli.py:388
```

## Change

- add the missing `continue`
- add `tests/test_cli.py` covering `sync_handler`: a failure in the middle, a failure on the first entry, `RAISE` still propagating, and the all-succeed path

`sync_handler` had no test coverage before this.

## Checks

Run from a clean checkout after `uv sync --all-extras`:

- `./scripts/test` — 35 passed (31 existing + 4 new)
- `./scripts/lint` — All checks passed
- `./scripts/typecheck` — Success: no issues found in 24 source files
- `uv lock --check` — no change

Refs #247
