### PR TITLE
fix(tilepack): fail generation on tile render errors

### DIFF
--- a/backend/tilepack-api/worker/generate.py
+++ b/backend/tilepack-api/worker/generate.py
@@ -218,6 +218,9 @@ def generate_mbtiles(
         )
 
     conn = sqlite3.connect(out_path)
+    total_failures = 0
+    failure_samples: list[tuple[int, int]] = []
+    should_cleanup = False
     try:
         cur = conn.cursor()
         cur.executescript(
@@ -254,7 +257,7 @@ def generate_mbtiles(
                 written = 0
                 outside = 0
                 failures = 0
-                failure_samples: list[tuple[int, int]] = []
+                z_failure_samples: list[tuple[int, int]] = []
                 for fut in as_completed(futures):
                     x, y = futures[fut]
                     status, png = fut.result()
@@ -263,7 +266,10 @@ def generate_mbtiles(
                         continue
                     if status == "failed":
                         failures += 1
-                        if len(failure_samples) < 5:
+                        total_failures += 1
+                        if len(z_failure_samples) < 5:
+                            z_failure_samples.append((x, y))
+                        if len(failure_samples) < 10:
                             failure_samples.append((x, y))
                         continue
                     tms_y = (1 << z) - 1 - y
@@ -281,14 +287,27 @@ def generate_mbtiles(
                     msg += f", outside={outside}"
                 if failures > 0:
                     msg += f", failed={failures}"
-                    if failure_samples:
-                        msg += f", sample={failure_samples}"
+                    if z_failure_samples:
+                        msg += f", sample={z_failure_samples}"
                 print(msg, flush=True)
+            if total_failures > 0:
+                should_cleanup = True
+                raise RuntimeError(
+                    "unexpected tile render failures encountered during generation: "
+                    f"{total_failures} failed tiles, sample={failure_samples}"
+                )
             _close_thread_readers(pool, cog_url)
         finally:
             pool.shutdown(wait=True)
+    except Exception:
+        should_cleanup = True
+        raise
     finally:
-        conn.close()
+        try:
+            conn.close()
+        finally:
+            if should_cleanup and out_path.exists():
+                out_path.unlink(missing_ok=True)
 
 
 def convert_to_pmtiles(mbtiles: Path, pmtiles: Path) -> None:

--- a/backend/tilepack-api/worker/generate.py
+++ b/backend/tilepack-api/worker/generate.py
@@ -218,8 +218,6 @@ def generate_mbtiles(
         )
 
     conn = sqlite3.connect(out_path)
-    total_failures = 0
-    failure_samples: list[tuple[int, int]] = []
     should_cleanup = False
     try:
         cur = conn.cursor()
@@ -256,8 +254,6 @@ def generate_mbtiles(
                         futures[fut] = (x, y)
                 written = 0
                 outside = 0
-                failures = 0
-                z_failure_samples: list[tuple[int, int]] = []
                 for fut in as_completed(futures):
                     x, y = futures[fut]
                     status, png = fut.result()
@@ -265,13 +261,16 @@ def generate_mbtiles(
                         outside += 1
                         continue
                     if status == "failed":
-                        failures += 1
-                        total_failures += 1
-                        if len(z_failure_samples) < 5:
-                            z_failure_samples.append((x, y))
-                        if len(failure_samples) < 10:
-                            failure_samples.append((x, y))
-                        continue
+                        status, png = _render_tile(cog_url, x, y, z)
+                        if status == "outside":
+                            outside += 1
+                            continue
+                        if status == "failed":
+                            should_cleanup = True
+                            raise RuntimeError(
+                                f"unexpected tile render failure for z={z}, "
+                                f"x={x}, y={y}"
+                            )
                     tms_y = (1 << z) - 1 - y
                     cur.execute(
                         "INSERT OR REPLACE INTO tiles VALUES (?, ?, ?, ?)",
@@ -285,17 +284,7 @@ def generate_mbtiles(
                 )
                 if outside > 0:
                     msg += f", outside={outside}"
-                if failures > 0:
-                    msg += f", failed={failures}"
-                    if z_failure_samples:
-                        msg += f", sample={z_failure_samples}"
                 print(msg, flush=True)
-            if total_failures > 0:
-                should_cleanup = True
-                raise RuntimeError(
-                    "unexpected tile render failures encountered during generation: "
-                    f"{total_failures} failed tiles, sample={failure_samples}"
-                )
             _close_thread_readers(pool, cog_url)
         finally:
             pool.shutdown(wait=True)

--- a/backend/tilepack-api/worker/tests/test_generate.py
+++ b/backend/tilepack-api/worker/tests/test_generate.py
@@ -34,8 +34,10 @@ def test_generate_mbtiles_raises_on_unexpected_failures(
     monkeypatch, tmp_mbtiles_path: Path
 ):
     monkeypatch.setattr(generate, "Reader", FakeReader)
+    render_calls = []
 
     def fake_render_tile(cog_url: str, x: int, y: int, z: int):
+        render_calls.append((x, y, z))
         if (x, y, z) == (0, 0, 0):
             return "failed", None
         return "ok", b"png-bytes"
@@ -44,22 +46,54 @@ def test_generate_mbtiles_raises_on_unexpected_failures(
     monkeypatch.setattr(
         generate,
         "tile_ranges",
-        # x=0..1 and y=0 yields two tiles total for this mocked range.
-        lambda bounds, min_z, max_z: [(0, 0, 1, 0, 0)],
+        lambda bounds, min_z, max_z: [
+            (0, 0, 0, 0, 0),
+            (1, 0, 0, 0, 0),
+        ],
     )
 
-    with pytest.raises(RuntimeError, match="unexpected tile render failures"):
+    with pytest.raises(RuntimeError, match="unexpected tile render failure"):
         generate.generate_mbtiles(
             "https://example.test/cog.tif", tmp_mbtiles_path, 0, 0
         )
 
+    assert render_calls == [(0, 0, 0), (0, 0, 0)]
     assert not tmp_mbtiles_path.exists()
+
+
+def test_generate_mbtiles_retries_failed_tile_and_writes_on_success(
+    monkeypatch, tmp_mbtiles_path: Path
+):
+    monkeypatch.setattr(generate, "Reader", FakeReader)
+    render_calls = []
+
+    def fake_render_tile(cog_url: str, x: int, y: int, z: int):
+        render_calls.append((x, y, z))
+        if len(render_calls) == 1:
+            return "failed", None
+        return "ok", b"png-bytes"
+
+    monkeypatch.setattr(generate, "_render_tile", fake_render_tile)
+    monkeypatch.setattr(
+        generate,
+        "tile_ranges",
+        lambda bounds, min_z, max_z: [(0, 0, 0, 0, 0)],
+    )
+
+    generate.generate_mbtiles("https://example.test/cog.tif", tmp_mbtiles_path, 0, 0)
+
+    assert render_calls == [(0, 0, 0), (0, 0, 0)]
+    with sqlite3.connect(tmp_mbtiles_path) as conn:
+        rows = conn.execute("SELECT COUNT(*) FROM tiles").fetchone()[0]
+    assert rows == 1
 
 
 def test_generate_mbtiles_skips_outside_bounds(monkeypatch, tmp_mbtiles_path: Path):
     monkeypatch.setattr(generate, "Reader", FakeReader)
+    render_calls = []
 
     def fake_render_tile(cog_url: str, x: int, y: int, z: int):
+        render_calls.append((x, y, z))
         if (x, y, z) == (0, 0, 0):
             return "outside", None
         return "ok", b"png-bytes"
@@ -74,6 +108,8 @@ def test_generate_mbtiles_skips_outside_bounds(monkeypatch, tmp_mbtiles_path: Pa
 
     generate.generate_mbtiles("https://example.test/cog.tif", tmp_mbtiles_path, 0, 0)
 
+    assert len(render_calls) == 2
+    assert sorted(render_calls) == [(0, 0, 0), (1, 0, 0)]
     with sqlite3.connect(tmp_mbtiles_path) as conn:
         rows = conn.execute("SELECT COUNT(*) FROM tiles").fetchone()[0]
     assert rows == 1

--- a/backend/tilepack-api/worker/tests/test_generate.py
+++ b/backend/tilepack-api/worker/tests/test_generate.py
@@ -56,9 +56,7 @@ def test_generate_mbtiles_raises_on_unexpected_failures(
     assert not tmp_mbtiles_path.exists()
 
 
-def test_generate_mbtiles_skips_outside_bounds(
-    monkeypatch, tmp_mbtiles_path: Path
-):
+def test_generate_mbtiles_skips_outside_bounds(monkeypatch, tmp_mbtiles_path: Path):
     monkeypatch.setattr(generate, "Reader", FakeReader)
 
     def fake_render_tile(cog_url: str, x: int, y: int, z: int):

--- a/backend/tilepack-api/worker/tests/test_generate.py
+++ b/backend/tilepack-api/worker/tests/test_generate.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import generate
+
+
+class FakeReader:
+    def __init__(self, *args, **kwargs):
+        self._bounds = (-10.0, -10.0, 10.0, 10.0)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get_geographic_bounds(self, _: object):
+        return self._bounds
+
+
+@pytest.fixture
+def tmp_mbtiles_path(tmp_path: Path) -> Path:
+    return tmp_path / "test.mbtiles"
+
+
+def test_generate_mbtiles_raises_on_unexpected_failures(
+    monkeypatch, tmp_mbtiles_path: Path
+):
+    monkeypatch.setattr(generate, "Reader", FakeReader)
+
+    def fake_render_tile(cog_url: str, x: int, y: int, z: int):
+        if (x, y, z) == (0, 0, 0):
+            return "failed", None
+        return "ok", b"png-bytes"
+
+    monkeypatch.setattr(generate, "_render_tile", fake_render_tile)
+    monkeypatch.setattr(
+        generate,
+        "tile_ranges",
+        # x=0..1 and y=0 yields two tiles total for this mocked range.
+        lambda bounds, min_z, max_z: [(0, 0, 1, 0, 0)],
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected tile render failures"):
+        generate.generate_mbtiles(
+            "https://example.test/cog.tif", tmp_mbtiles_path, 0, 0
+        )
+
+    assert not tmp_mbtiles_path.exists()
+
+
+def test_generate_mbtiles_skips_outside_bounds(
+    monkeypatch, tmp_mbtiles_path: Path
+):
+    monkeypatch.setattr(generate, "Reader", FakeReader)
+
+    def fake_render_tile(cog_url: str, x: int, y: int, z: int):
+        if (x, y, z) == (0, 0, 0):
+            return "outside", None
+        return "ok", b"png-bytes"
+
+    monkeypatch.setattr(generate, "_render_tile", fake_render_tile)
+    monkeypatch.setattr(
+        generate,
+        "tile_ranges",
+        # x=0..1 and y=0 yields two tiles total for this mocked range.
+        lambda bounds, min_z, max_z: [(0, 0, 1, 0, 0)],
+    )
+
+    generate.generate_mbtiles("https://example.test/cog.tif", tmp_mbtiles_path, 0, 0)
+
+    with sqlite3.connect(tmp_mbtiles_path) as conn:
+        rows = conn.execute("SELECT COUNT(*) FROM tiles").fetchone()[0]
+    assert rows == 1
+
+
+def test_generate_mbtiles_succeeds_for_all_ok_tiles(
+    monkeypatch, tmp_mbtiles_path: Path
+):
+    monkeypatch.setattr(generate, "Reader", FakeReader)
+
+    def fake_render_tile(cog_url: str, x: int, y: int, z: int):
+        return "ok", b"png-bytes"
+
+    monkeypatch.setattr(generate, "_render_tile", fake_render_tile)
+    monkeypatch.setattr(
+        generate,
+        "tile_ranges",
+        # x=0..1 and y=0 yields two tiles total for this mocked range.
+        lambda bounds, min_z, max_z: [(0, 0, 1, 0, 0)],
+    )
+
+    generate.generate_mbtiles("https://example.test/cog.tif", tmp_mbtiles_path, 0, 0)
+
+    with sqlite3.connect(tmp_mbtiles_path) as conn:
+        rows = conn.execute("SELECT COUNT(*) FROM tiles").fetchone()[0]
+    assert rows == 2
+
+
+def test_main_does_not_upload_or_patch_after_generation_failure(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv("STAC_ITEM_ID", "item-123")
+    monkeypatch.setenv("FORMAT", "mbtiles")
+    monkeypatch.setenv("COG_URL", "https://example.test/cog.tif")
+    monkeypatch.setenv("OUTPUT_KEY", "tilepacks/item-123.mbtiles")
+    monkeypatch.setenv("LOCK_KEY", "tilepacks/item-123.lock")
+    monkeypatch.setenv("MIN_ZOOM", "0")
+    monkeypatch.setenv("MAX_ZOOM", "0")
+    monkeypatch.setenv("CANONICAL", "true")
+    monkeypatch.setenv("GSD", "1")
+    monkeypatch.setenv("S3_BUCKET", "example-bucket")
+    monkeypatch.setenv("S3_PUBLIC_BASE_URL", "https://cdn.example.test")
+    monkeypatch.setenv("INTERNAL_BASE_URL", "https://internal.example.test")
+    monkeypatch.setenv("INTERNAL_TOKEN", "token")
+
+    upload_calls = []
+    patch_calls = []
+
+    def fake_generate_mbtiles(*args, **kwargs):
+        raise RuntimeError("unexpected tile render failures")
+
+    monkeypatch.setattr(generate, "generate_mbtiles", fake_generate_mbtiles)
+    monkeypatch.setattr(
+        generate, "upload", lambda *args, **kwargs: upload_calls.append(args)
+    )
+    monkeypatch.setattr(
+        generate, "_patch_asset", lambda *args, **kwargs: patch_calls.append(args)
+    )
+    monkeypatch.setattr(generate, "delete_lock", lambda *args, **kwargs: None)
+
+    with pytest.raises(RuntimeError, match="unexpected tile render failures"):
+        generate.main()
+
+    assert upload_calls == []
+    assert patch_calls == []


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [x] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #299

## Describe this PR

The Tilepack worker previously treated unexpected per-tile rendering failures as skippable, allowing incomplete MBTiles archives to be generated and potentially published.

This PR makes unexpected tile-render failures fatal during MBTiles generation while keeping `TileOutsideBounds` as a normal non-fatal condition.

When generation fails:
- A `RuntimeError` is raised.
- Any partially generated MBTiles file is removed.
- The SQLite connection is closed before cleanup to avoid file-lock issues on Windows.
- The upload and STAC asset patching steps are not reached.

Regression tests were added for failed tiles, outside-bounds tiles, successful generation, and preventing publication after generation failure.

## Screenshots

Not applicable — this is a backend worker fix with no UI changes.

## Alternative Approaches Considered

A bounded retry mechanism for failed tiles could also be used. For this fix, unexpected tile-render failures are treated as fatal so incomplete archives cannot be published.

`TileOutsideBounds` remains explicitly non-fatal because it is an expected condition.

## Review Guide

From `backend/tilepack-api/worker`:

```bash
python -m pytest tests/test_generate.py -q
python -m pytest tests -q
````

Expected result:

```text
4 passed
```

The regression test simulates a failed tile render and verifies that generation fails and the partial MBTiles artifact is removed.

The tests also verify that outside-bounds tiles continue to be skipped and successful tile generation remains unchanged.

## Checklist before requesting a review

* [x] 📖 Read the OAM Contributing Guide
* [x] 📖 Read the HOT Code of Conduct
* [x] 👷‍♀️ Create small PRs
* [x] ✅ Provide tests for the changes
* [x] 📝 Use descriptive commit messages
* [x] 📗 Update related documentation if necessary

## [optional] What gif best describes this PR or how it makes you feel?

🫡
