### PR TITLE
Publish 0.2.0 OAM schema after new uploader-api additions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,24 +47,12 @@ repos:
       - id: oxfmt
         name: oxfmt
         files: ^
-        entry: bash -c 'test "$#" -gt 0 && oxfmt --write "$@" || exit 0' --
+        # oxfmt batches it's runs, so using !/path/to/file in args can cause issues
+        exclude: ^(?:CHANGELOG\.md|frontend/pnpm-lock\.yaml|backend/(?:global-tms|tilepack-api|stac-ingester|stac-api|global-mosaic|uploader-api|stactools-hotosm)/|docs/oam/|notebooks/)
+        entry: oxfmt --write
         language: node
         "types": [text]
         additional_dependencies: ["oxfmt@0.35.0"]
-        args:
-          [
-            "!CHANGELOG.md",
-            "!frontend/pnpm-lock.yaml",
-            "!backend/global-tms/**",
-            "!backend/tilepack-api/**",
-            "!backend/stac-ingester/**",
-            "!backend/stac-api/**",
-            "!backend/global-mosaic/**",
-            "!backend/uploader-api/**",
-            "!backend/stactools-hotosm/**",
-            "!docs/oam/**",
-            "!notebooks/**",
-          ]
 
   # # Lint: Dockerfile (disabled until binary is bundled)
   # - repo: https://github.com/hadolint/hadolint.git

--- a/backend/stactools-hotosm/README.md
+++ b/backend/stactools-hotosm/README.md
@@ -57,21 +57,39 @@ The `__version__` is kept only as a static string for STAC provenance.
 `stac-extension/` defines the OpenAerialMap STAC extension - see its
 [README](./stac-extension/README.md).
 
-`json-schema/schema.json` is the source of truth, both for editing and for the
-local validation in `tests/test_stac_extension.py`. It is published at
+`json-schema/schema.json` is the source of truth for the **current** version,
+both for editing and for the local validation in `tests/test_stac_extension.py`.
+It is published at
 
 ```text
-https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json
+https://docs.imagery.hotosm.org/oam/v0.2.0/schema.json
 ```
 
 which is its `$id`, and the URI `create_item` puts in `stac_extensions`.
 
-Publishing happens through the mkdocs site: `docs/oam/v0.1.0/schema.json` is a
-symlink to this file, so every push that changes it redeploys the schema along
-with the docs. To cut a new extension version, copy the symlink to
-`docs/oam/v{version}/schema.json`, bump `$id` and
-`OAM_EXTENSION_DEFAULT_VERSION`, and leave the older paths in place - Items
-already in pgstac keep pointing at them.
+Publishing happens through the mkdocs site: `docs/oam/v{version}/schema.json`
+symlinks to the schema for that version, so every push that changes one
+redeploys it along with the docs. Superseded versions are frozen as real files
+under `src/stactools/hotosm/schemas/oam/v{version}/`, with the `docs/oam`
+symlink pointing at the frozen copy.
+
+To create a new version:
+
+1. Freeze the outgoing one: copy `json-schema/schema.json` over
+   `src/stactools/hotosm/schemas/oam/v{old}/schema.json` and point
+   `docs/oam/v{old}/schema.json` at it. Its URI must keep serving the old
+   definition, which names itself in `$id` and in the `stac_extensions`
+   `contains` check - serve the new schema there and every Item using it stops
+   validating.
+2. Bump `$id` in `json-schema/schema.json`, then symlink `docs/oam/v{new}/` and
+   `schemas/oam/v{new}/` to it.
+3. Add the version to `OAM_EXTENSION_SUPPORTED_VERSIONS` and set
+   `OAM_EXTENSION_DEFAULT_VERSION`.
+4. Update `stac-extension/package.json`, the example Item, and the extension
+   README and CHANGELOG.
+
+`test_published_versions_are_frozen` checks steps 1-3 for every supported
+version.
 
 The schema was previously served from GitHub Pages on the standalone repo, at
 `https://hotosm.github.io/stactools-hotosm/oam/v0.1.0/schema.json`. That URL is

--- a/backend/stactools-hotosm/src/stactools/hotosm/constants.py
+++ b/backend/stactools-hotosm/src/stactools/hotosm/constants.py
@@ -10,5 +10,6 @@ COLLECTION_DESCRIPTION = (
 OAM_EXTENSION_SCHEMA_URI_PATTERN: str = (
     "https://docs.imagery.hotosm.org/oam/v{version}/schema.json"
 )
-OAM_EXTENSION_DEFAULT_VERSION: str = "0.1.0"
-OAM_EXTENSION_SUPPORTED_VERSIONS: list[str] = ["0.1.0"]
+OAM_EXTENSION_DEFAULT_VERSION: str = "0.2.0"
+# Older versions stay listed so Items already carrying them still validate.
+OAM_EXTENSION_SUPPORTED_VERSIONS: list[str] = ["0.1.0", "0.2.0"]

--- a/backend/stactools-hotosm/src/stactools/hotosm/schemas/oam/v0.1.0/schema.json
+++ b/backend/stactools-hotosm/src/stactools/hotosm/schemas/oam/v0.1.0/schema.json
@@ -1,1 +1,83 @@
-../../../../../../stac-extension/json-schema/schema.json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json",
+  "title": "OAM Extension",
+  "description": "STAC Extension for HOT OAM for STAC Items.",
+  "oneOf": [
+    {
+      "$comment": "This is the schema for STAC Items.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
+          "type": "object",
+          "required": ["type", "properties", "assets"],
+          "properties": {
+            "type": {
+              "const": "Feature"
+            },
+            "properties": {
+              "allOf": [
+                {
+                  "$comment": "Require fields here for Item Properties.",
+                  "required": ["gsd", "oam:platform_type", "oam:producer_name"]
+                },
+                {
+                  "$ref": "#/definitions/fields"
+                }
+              ]
+            },
+            "assets": {
+              "$comment": "This validates the fields in Item Assets, but does not require them.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": ["stac_extensions"],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json"
+          }
+        }
+      }
+    },
+    "fields": {
+      "$comment": "Add your new fields here. Don't require them here, do that above in the corresponding schema.",
+      "type": "object",
+      "properties": {
+        "oam:platform_type": {
+          "description": "The type of platform that acquired the imagery.",
+          "type": "string",
+          "enum": ["kite", "balloon", "uav", "aircraft", "satellite"]
+        },
+        "oam:producer_name": {
+          "description": "The data producer's name. This should match an entry in the Providers object.",
+          "type": "string"
+        },
+        "license": {
+          "description": "If defined, the Item level license must be a Creative Commons license.",
+          "type": "string",
+          "enum": ["CC-BY-SA-4.0", "CC-BY-4.0", "CC-BY-NC-4.0"]
+        }
+      },
+      "patternProperties": {
+        "^(?!oam:)": {
+          "$comment": "Validate fields with `oam` prefix"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/backend/stactools-hotosm/src/stactools/hotosm/schemas/oam/v0.2.0/schema.json
+++ b/backend/stactools-hotosm/src/stactools/hotosm/schemas/oam/v0.2.0/schema.json
@@ -1,0 +1,1 @@
+../../../../../../stac-extension/json-schema/schema.json

--- a/backend/stactools-hotosm/stac-extension/CHANGELOG.md
+++ b/backend/stactools-hotosm/stac-extension/CHANGELOG.md
@@ -11,16 +11,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The schema is now published from `https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json`,
-  and `$id` points there. The previous location,
-  `https://hotosm.github.io/stactools-hotosm/oam/v0.1.0/schema.json`, served the
-  same v0.1.0 definition from the now-archived standalone repository.
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+## [v0.2.0]
+
+### Added
+
+- `oam:product_type`, `oam:product_type_source` - what kind of imagery the data
+  asset holds, and whether that was declared or detected.
+- `oam:footprint_source`, `oam:footprint_area` - how the Item geometry was
+  derived, and the area it covers.
+- `oam:acquisition_time_estimated`, `oam:acquisition_source` - marks an
+  estimated acquisition datetime, and where it came from.
+- `oam:external_id` - identifier in the system that submitted the imagery.
+
+All optional, and the required fields are unchanged, so a v0.1.0 Item is a
+valid v0.2.0 Item once its `stac_extensions` entry is updated.
+
+### Changed
+
+- The schema is now published from `https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json`,
+  and `$id` points there. The previous location,
+  `https://hotosm.github.io/stactools-hotosm/oam/v0.1.0/schema.json`, served the
+  same v0.1.0 definition from the now-archived standalone repository.
 
 ## [v0.1.0]
 
@@ -29,4 +46,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First definition of the OAM STAC extension.
 
 [Unreleased]: https://github.com/hotosm/openaerialmap/tree/main/backend/stactools-hotosm/stac-extension
+[v0.2.0]: https://docs.imagery.hotosm.org/oam/v0.2.0/schema.json
 [v0.1.0]: https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json

--- a/backend/stactools-hotosm/stac-extension/README.md
+++ b/backend/stactools-hotosm/stac-extension/README.md
@@ -1,7 +1,7 @@
 # Humanitarian OpenStreetMap Team OpenAerialMap Extension Specification
 
 - **Title:** Humanitarian OpenStreetMap Team OpenAerialMap (OAM) Extension
-- **Identifier:** <https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json>
+- **Identifier:** <https://docs.imagery.hotosm.org/oam/v0.2.0/schema.json>
 - **Field Name Prefix:** oam
 - **Scope:** Item
 - **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Proposal
@@ -29,9 +29,16 @@ The fields in the table below can be used in these parts of STAC documents:
 | Field Name                                                                                            | Type   | Description                                                                                                                                                                                |
 | ----------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | oam:producer_name                                                                                     | string | **REQUIRED**. The name of the imagery data producer. The producer must also be included in the "Provider" field of STAC Items if the producer is not consistent for the entire Collection. |
-| oam:platform_type                                                                                     | string | **REQUIRED**. The platform type (kite, balloon, UAV, airplane, satellite)                                                                                                                  |
+| oam:platform_type                                                                                     | string | **REQUIRED**. The platform type (kite, balloon, UAV, aircraft, satellite)                                                                                                                  |
 | [gsd](https://github.com/radiantearth/stac-spec/blob/master/commons/common-metadata.md#gsd)           | number | **REQUIRED**. The Ground Sampling Distance                                                                                                                                                 |
 | [license](https://github.com/radiantearth/stac-spec/blob/master/commons/common-metadata.md#licensing) | string | If provided for STAC Items, must be a Creative Commons (CC) license.                                                                                                                       |
+| oam:product_type                                                                                      | string | The kind of imagery held by the data asset, which determines how it is displayed.                                                                                                          |
+| oam:product_type_source                                                                               | string | Whether the product type was `declared` by a person or `detected` from the raster.                                                                                                        |
+| oam:footprint_source                                                                                  | string | Whether the Item geometry traces the valid pixels (`mask`) or is the bounding rectangle (`bbox`).                                                                                          |
+| oam:footprint_area                                                                                    | number | Area covered by the Item geometry, in square metres.                                                                                                                                      |
+| oam:acquisition_time_estimated                                                                        | boolean | `true` when the acquisition datetime was estimated rather than supplied by the data provider.                                                                                             |
+| oam:acquisition_source                                                                                | string | Where the acquisition datetime came from. Omitted when the data provider supplied it.                                                                                                     |
+| oam:external_id                                                                                       | string | Identifier for this imagery in the external system that submitted it.                                                                                                                     |
 
 ### Additional Field Information
 
@@ -42,8 +49,35 @@ The type of the observation platform used to acquire the imagery. The platform t
 - `kite`
 - `balloon`
 - `uav`
-- `airplane`
+- `aircraft`
 - `satellite`
+
+#### oam:product_type
+
+The kind of imagery held by the data asset, which selects the display
+parameters written to the [render extension](https://github.com/stac-extensions/render).
+
+- `visual` - a photograph, displayed as-is
+- `multispectral` - more bands than can be displayed at once
+- `sar` - synthetic aperture radar
+- `elevation` - height values rather than a picture
+- `pseudocolor` - a single band displayed through a colour palette
+
+`oam:product_type_source` is `declared` if a person set the type, `detected` if
+it was inferred from the raster.
+
+#### oam:footprint_source
+
+`mask` if the Item geometry traces the raster's valid pixels, `bbox` if it is
+the bounding rectangle. `oam:footprint_area` is the area it covers, in square
+metres.
+
+#### oam:acquisition_source
+
+Where an estimated acquisition datetime came from: `file-tags` (the image
+file's EXIF or TIFF tags) or `ingest` (the time of ingestion, when nothing
+better was available). `oam:acquisition_time_estimated` is `true` in both
+cases.
 
 #### Provider
 

--- a/backend/stactools-hotosm/stac-extension/examples/item.json
+++ b/backend/stactools-hotosm/stac-extension/examples/item.json
@@ -5,7 +5,7 @@
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
     "https://stac-extensions.github.io/alternate-assets/v1.2.0/schema.json",
-    "https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json"
+    "https://docs.imagery.hotosm.org/oam/v0.2.0/schema.json"
   ],
   "id": "59e62b903d6412ef7220a02f",
   "geometry": {
@@ -51,7 +51,7 @@
     "title": "Pisgah Crater Cinder Cone",
     "oam:producer_name": "redacted",
     "oam:platform_type": "uav",
-    "gsd": 2.990237944881498e-7,
+    "gsd": 2.990237944881498e-07,
     "license": "CC-BY-4.0",
     "instruments": [
       "Phantom 3 Pro"
@@ -67,7 +67,11 @@
           "licensor"
         ]
       }
-    ]
+    ],
+    "oam:product_type": "visual",
+    "oam:product_type_source": "declared",
+    "oam:footprint_source": "mask",
+    "oam:footprint_area": 812345.6
   },
   "assets": {
     "image": {
@@ -114,11 +118,11 @@
         30505
       ],
       "proj:transform": [
-        3.276234535837461e-7,
+        3.276234535837461e-07,
         0,
         -116.38018350872744,
         0,
-        -2.704241353925534e-7,
+        -2.704241353925534e-07,
         34.75077985936304,
         0,
         0,

--- a/backend/stactools-hotosm/stac-extension/json-schema/schema.json
+++ b/backend/stactools-hotosm/stac-extension/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json",
+  "$id": "https://docs.imagery.hotosm.org/oam/v0.2.0/schema.json",
   "title": "OAM Extension",
   "description": "STAC Extension for HOT OAM for STAC Items.",
   "oneOf": [
@@ -48,7 +48,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json"
+            "const": "https://docs.imagery.hotosm.org/oam/v0.2.0/schema.json"
           }
         }
       }
@@ -64,6 +64,45 @@
         },
         "oam:producer_name": {
           "description": "The data producer's name. This should match an entry in the Providers object.",
+          "type": "string"
+        },
+        "oam:product_type": {
+          "description": "The kind of imagery the data asset holds, which determines how it is displayed.",
+          "type": "string",
+          "enum": [
+            "visual",
+            "multispectral",
+            "sar",
+            "elevation",
+            "pseudocolor"
+          ]
+        },
+        "oam:product_type_source": {
+          "description": "Whether the product type was declared by a person or detected from the raster.",
+          "type": "string",
+          "enum": ["declared", "detected"]
+        },
+        "oam:footprint_source": {
+          "description": "Whether the Item geometry traces the valid pixels of the raster, or is its bounding rectangle.",
+          "type": "string",
+          "enum": ["mask", "bbox"]
+        },
+        "oam:footprint_area": {
+          "description": "Area covered by the Item geometry, in square metres.",
+          "type": "number",
+          "minimum": 0
+        },
+        "oam:acquisition_time_estimated": {
+          "description": "True when the acquisition datetime was estimated rather than supplied by the data provider.",
+          "type": "boolean"
+        },
+        "oam:acquisition_source": {
+          "description": "Where the acquisition datetime came from. Omitted when supplied by the data provider.",
+          "type": "string",
+          "enum": ["user", "file-tags", "ingest"]
+        },
+        "oam:external_id": {
+          "description": "Identifier for this imagery in the external system that submitted it.",
           "type": "string"
         },
         "license": {

--- a/backend/stactools-hotosm/stac-extension/package.json
+++ b/backend/stactools-hotosm/stac-extension/package.json
@@ -1,11 +1,11 @@
 {
   "name": "oam",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "scripts": {
     "test": "npm run check-markdown && npm run check-examples",
     "check-markdown": "remark . -f -r remark.yaml",
-    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json=./json-schema/schema.json",
-    "format-examples": "stac-node-validator . --format --schemaMap https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json=./json-schema/schema.json"
+    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://docs.imagery.hotosm.org/oam/v0.2.0/schema.json=./json-schema/schema.json",
+    "format-examples": "stac-node-validator . --format --schemaMap https://docs.imagery.hotosm.org/oam/v0.2.0/schema.json=./json-schema/schema.json"
   },
   "dependencies": {
     "remark-cli": "^12.0.0",

--- a/backend/stactools-hotosm/tests/test_stac_extension.py
+++ b/backend/stactools-hotosm/tests/test_stac_extension.py
@@ -10,6 +10,7 @@ from pystac.validation import JsonSchemaSTACValidator
 from stactools.hotosm.constants import (
     OAM_EXTENSION_DEFAULT_VERSION,
     OAM_EXTENSION_SCHEMA_URI_PATTERN,
+    OAM_EXTENSION_SUPPORTED_VERSIONS,
 )
 from stactools.hotosm.oam_extension import load_oam_extension_schema
 from stactools.hotosm.oam_metadata import OamMetadata
@@ -40,6 +41,18 @@ def test_stac_extension_is_published_through_docs():
     published = DOCS_DIR.joinpath(OAM_EXT_SCHEMA.removeprefix(DOCS_SITE_URL))
     assert published.is_file()
     assert published.read_bytes() == OAM_STAC_EXTENSION_PATH.read_bytes()
+
+
+@pytest.mark.parametrize("version", OAM_EXTENSION_SUPPORTED_VERSIONS)
+def test_published_versions_are_frozen(version: str):
+    """Ensure older schema versions don't accidentally change."""
+    schema_uri = OAM_EXTENSION_SCHEMA_URI_PATTERN.format(version=version)
+    schema = load_oam_extension_schema(version)
+
+    assert schema["$id"] == schema_uri
+    published = DOCS_DIR.joinpath(schema_uri.removeprefix(DOCS_SITE_URL))
+    assert published.is_file()
+    assert json.loads(published.read_text()) == schema
 
 
 def test_stac_extension_is_bundled_in_package():

--- a/backend/uploader-api/README.md
+++ b/backend/uploader-api/README.md
@@ -27,8 +27,9 @@ uploader-api ──submit──▶ Argo workflow:
 ```
 
 Browser uploads go directly to S3; remote uploads provide a `source_url` that
-the pipeline fetches. See
-[Integrating an external system](#integrating-an-external-system).
+the pipeline fetches, either pasted into the form (see
+[Importing from a link](#importing-from-a-link)) or handed over by a partner
+system (see [Integrating an external system](#integrating-an-external-system)).
 
 - **`app/uploads/`**: upload lifecycle, storage/catalogue clients, Argo trigger,
   and workflow callbacks.
@@ -108,6 +109,63 @@ uv run uvicorn app.main:app --reload --port 8080
 
 Config is via environment variables. See `.env.example`.
 
+## Importing from a link
+
+The upload form takes either a GeoTIFF from the computer or a link we fetch it
+from. The second exists because the imagery is usually already on a server, and
+downloading it only to upload it again is the expensive part for anyone on a thin
+connection.
+
+A link has to be reachable over public HTTPS and has to return the GeoTIFF
+itself. `app/uploads/source_links.py` rewrites the share links that have a direct
+equivalent and rejects the rest with a message naming the fix; whatever comes out
+goes through `url_guard` like any other URL.
+
+- **Object storage**: paste presigned or public URLs as they are. S3 and
+  S3-compatible (MinIO, R2, B2, Wasabi, Spaces), Google Cloud Storage and Azure
+  Blob all serve bytes directly, so nothing is rewritten. This is the ScaleODM
+  path.
+- **NodeODM**: `https://your-node/task/<uuid>/download/all.zip`, with `?token=…`
+  if the node has one. NodeODM 2 removed direct asset downloads, so the fetch
+  step reads only `odm_orthophoto/odm_orthophoto.tif` from the archive. Legacy
+  `orthophoto.tif` links are rewritten to `all.zip`.
+- **WebODM**: a public task's `orthophoto.tif` or `all.zip` download URL. Private
+  tasks still require the JWT header we deliberately do not collect.
+- **OneDrive / SharePoint**: the file's share link as it came. A
+  `*.sharepoint.com` link gets `download=1`; a consumer `1drv.ms` or
+  `onedrive.live.com` link is resolved through `api.onedrive.com/v1.0/shares`.
+- **Dropbox**: the file's share link as it came; we force `dl=1`.
+- **Google Drive**: the file's share link as it came; we rewrite it to
+  `drive.usercontent.google.com/download?…&confirm=t`.
+
+One shape we handle narrowly and one we refuse on purpose:
+
+- **ODM archives.** NodeODM exposes only `all.zip`, so fetch streams that archive
+  under the normal size ceiling and reads one exact member without extracting
+  paths or sidecars. Arbitrary archive URLs and unrelated ODM assets are refused.
+- **Anything needing a login credential.** Private WebODM tasks, and Drive or
+  OneDrive files that are not shared publicly, need an `Authorization` header we
+  do not send: a capability URL that expires is a very different thing to store
+  than a partner's login token.
+
+And four we cannot support at all, so the form says so rather than failing
+obscurely: MEGA (client-side decryption), WeTransfer and similar (ephemeral,
+POST-gated), iCloud Drive (JavaScript share pages), and chat apps (no stable
+URL). All of them mean downloading the file and uploading it as a file.
+
+Two rewrites are undocumented and have moved before, so treat a failure as the
+recipe going stale rather than user error - the fetch step's TIFF sniff catches
+it and tells the user to link straight to the file:
+
+- Drive's `confirm=t`, which suppresses the "can't scan this file" page. A
+  `resourcekey` carried by the shared link is retained.
+- The unauthenticated `api.onedrive.com` shares endpoint. Both it and SharePoint's
+  `download=1` want checking against a live tenant.
+
+A platform that holds its own auth should use the prefill handoff below instead:
+it mints the presigned URL and fills in the metadata it already knows, so we
+never store its credentials.
+
 ## Integrating an external system
 
 A partner can prefill the upload form without exchanging API tokens: send the
@@ -145,6 +203,8 @@ already published.
 
 - The Litestar service: DB layer, auth deps, S3 multipart and Argo routes, upload
   and profile pages.
+- Both ingest paths in the form: a file picker and a link box, with share links
+  normalised in `app/uploads/source_links.py`.
 - `pipeline/`: the `WorkflowTemplate` and five step images. Metadata uses
   `stactools-hotosm` from `backend/stactools-hotosm`, the same source tree as
   `backend/stac-ingester`.

--- a/backend/uploader-api/app/static/css/app.css
+++ b/backend/uploader-api/app/static/css/app.css
@@ -173,6 +173,112 @@ hotosm-auth {
   background: var(--oam-grey-50);
 }
 
+/* Source chooser: upload a file, or import from a link. */
+.oam-source {
+  margin: 0;
+  padding: 0;
+  border: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* The form reads as two steps; a legend and an h2 have to be made to match. */
+.oam-form__heading,
+.oam-source legend {
+  margin: 0.5rem 0 0;
+  padding: 0;
+  font-family: "Archivo", sans-serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--oam-bluedark);
+}
+
+.oam-form__heading {
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--oam-greylight);
+}
+
+.oam-source__option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  padding: 0.75rem;
+  border: 1px solid var(--oam-greylight);
+  border-radius: 8px;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.oam-source__option:hover {
+  border-color: var(--oam-grey-300);
+  background: var(--oam-grey-50);
+}
+
+/* :has, so the whole card reads as selected, not just the radio. */
+.oam-source__option:has(input:checked) {
+  border-color: var(--oam-red);
+  background: var(--oam-redlight);
+}
+
+.oam-source__option input {
+  margin: 0.2rem 0 0;
+  accent-color: var(--oam-red);
+}
+
+.oam-source__option strong {
+  display: block;
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.oam-source__option small {
+  display: block;
+  font-family: "Manrope", sans-serif;
+  font-size: 0.8125rem;
+  color: var(--oam-bluegrey);
+}
+
+.oam-source__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.oam-source__note {
+  margin: 0;
+  font-family: "Manrope", sans-serif;
+  font-size: 0.8125rem;
+  color: var(--oam-bluegrey);
+}
+
+.oam-source__help {
+  font-family: "Manrope", sans-serif;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--oam-grey-800);
+}
+
+.oam-source__help h4 {
+  margin: 1rem 0 0.25rem;
+  font-family: "Archivo", sans-serif;
+  font-size: 0.875rem;
+  color: var(--oam-bluedark);
+}
+
+.oam-source__help p {
+  margin: 0;
+}
+
+.oam-source__help code {
+  /* Long URLs in a narrow column; breaking beats overflowing. */
+  overflow-wrap: anywhere;
+  font-size: 0.78125rem;
+  padding: 0.05rem 0.25rem;
+  border-radius: 4px;
+  background: var(--oam-grey-100);
+}
+
 .oam-progress {
   margin-top: 1rem;
   display: flex;

--- a/backend/uploader-api/app/static/js/uploader.js
+++ b/backend/uploader-api/app/static/js/uploader.js
@@ -122,12 +122,88 @@ function externalLink(form) {
   };
 }
 
+// Advisory only: the server decides, in `app/uploads/source_links.py`. Keep these
+// hosts in step with it so the form never promises a rewrite it will not do.
+const DRIVE_HOSTS = ["drive.google.com", "docs.google.com", "drive.usercontent.google.com"];
+const DROPBOX_HOSTS = ["www.dropbox.com", "dropbox.com"];
+const ONEDRIVE_HOSTS = ["1drv.ms", "onedrive.live.com"];
+const ODM_ASSET_PATH = /^\/task\/[\w-]+\/download\/([^/]+)$/;
+const WEBODM_ASSET_PATH = /^\/api\/projects\/\d+\/tasks\/[^/]+\/download\/([^/]+)\/?$/;
+
+function sourceHint(raw) {
+  const value = raw.trim();
+  if (!value) return "";
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return "";
+  }
+  if (parsed.protocol !== "https:") {
+    return "The link has to start with https:// to be imported.";
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (DRIVE_HOSTS.includes(host)) {
+    return (
+      "Google Drive link. We will rewrite it to Drive's download endpoint. " +
+      "If Drive refuses to serve the file, upload it instead."
+    );
+  }
+  if (DROPBOX_HOSTS.includes(host)) {
+    return "Dropbox link. We will switch it to a direct download.";
+  }
+  if (ONEDRIVE_HOSTS.includes(host) || host.endsWith(".sharepoint.com")) {
+    return "OneDrive link. We will switch it to a direct download.";
+  }
+  const webodmAsset = parsed.pathname.match(WEBODM_ASSET_PATH);
+  if (webodmAsset) {
+    const asset = webodmAsset[1].toLowerCase();
+    if (asset === "orthophoto.tif") return "Public WebODM orthophoto link.";
+    if (asset === "all.zip") {
+      return "Public WebODM assets archive. We will safely extract only the orthophoto.";
+    }
+    return `We cannot use '${webodmAsset[1]}'. Link to orthophoto.tif or all.zip instead.`;
+  }
+  const asset = parsed.pathname.match(ODM_ASSET_PATH);
+  if (asset) {
+    const name = asset[1].toLowerCase();
+    if (name === "orthophoto.tif" || name === "all.zip") {
+      return "NodeODM link. We will download all.zip and safely extract only the orthophoto.";
+    }
+    return `We can only read the orthophoto, not '${asset[1]}'. Use the all.zip download link.`;
+  }
+  return "";
+}
+
+function currentMode(form) {
+  const picked = form.querySelector('input[name="source_mode"]:checked');
+  return picked ? picked.value : "file";
+}
+
+// `required` has to come off the input the user cannot see, or submit blocks silently.
+function applySourceMode(form) {
+  const mode = currentMode(form);
+  const fileInput = document.getElementById("file-input");
+  const urlInput = document.getElementById("source-url");
+  document.getElementById("file-picker").hidden = mode !== "file";
+  document.getElementById("url-picker").hidden = mode !== "url";
+  if (fileInput) fileInput.required = mode === "file";
+  if (urlInput) urlInput.required = mode === "url";
+  const submit = document.getElementById("submit-btn");
+  if (submit) submit.textContent = mode === "url" ? "Import imagery" : "Start upload";
+}
+
 // Switch the form from "pick a file" to "confirm this source".
 function enterRemoteSourceMode(sourceUrl) {
-  const picker = document.getElementById("file-picker");
   const fileInput = document.getElementById("file-input");
   if (fileInput) fileInput.required = false;
-  if (picker) picker.hidden = true;
+  const urlInput = document.getElementById("source-url");
+  if (urlInput) urlInput.required = false;
+  // The source is already decided, so the choice would only be misleading.
+  for (const id of ["source-choice", "file-picker", "url-picker"]) {
+    const el = document.getElementById(id);
+    if (el) el.hidden = true;
+  }
 
   let host = sourceUrl;
   try {
@@ -233,29 +309,65 @@ async function uploadFile(form, file) {
   if (window.htmx) window.htmx.trigger("#uploads-list", "load");
 }
 
+function showError(message) {
+  const errBox = document.getElementById("upload-error");
+  errBox.innerHTML = '<wa-callout variant="danger"><span></span></wa-callout>';
+  // textContent prevents server messages from injecting HTML.
+  errBox.querySelector("span").textContent = message;
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   const form = document.getElementById("upload-form");
   if (!form) return;
-  const sourceUrl = applyPrefill(form);
-  if (sourceUrl) enterRemoteSourceMode(sourceUrl);
+  // A prefilled URL is a partner handoff: it answers this form's first question.
+  const prefilledUrl = applyPrefill(form);
+  if (prefilledUrl) {
+    enterRemoteSourceMode(prefilledUrl);
+  } else {
+    applySourceMode(form);
+    for (const radio of form.querySelectorAll('input[name="source_mode"]')) {
+      radio.addEventListener("change", () => applySourceMode(form));
+    }
+    const urlInput = document.getElementById("source-url");
+    const note = document.getElementById("source-url-note");
+    if (urlInput && note) {
+      const showHint = () => {
+        const hint = sourceHint(urlInput.value || "");
+        note.textContent = hint;
+        note.hidden = !hint;
+      };
+      // Which event a wa-input re-emits varies by version; the handler is idempotent.
+      for (const name of ["input", "wa-input", "change"]) {
+        urlInput.addEventListener(name, showHint);
+      }
+    }
+  }
 
   form.addEventListener("submit", async (e) => {
     e.preventDefault();
     const submit = document.getElementById("submit-btn");
-    const file = sourceUrl ? null : document.getElementById("file-input").files[0];
-    if (!sourceUrl && !file) return;
+    document.getElementById("upload-error").innerHTML = "";
+    const urlInput = document.getElementById("source-url");
+    const typedUrl = urlInput && !prefilledUrl ? (urlInput.value || "").trim() : "";
+    const remoteMode = Boolean(prefilledUrl) || currentMode(form) === "url";
+    const sourceUrl = prefilledUrl || typedUrl;
+    const file = remoteMode ? null : document.getElementById("file-input").files[0];
+
+    if (remoteMode && !sourceUrl) {
+      showError("Paste a link to the orthophoto, or upload a file instead.");
+      return;
+    }
+    if (!remoteMode && !file) return;
+
     submit.disabled = true;
     try {
-      if (sourceUrl) {
+      if (remoteMode) {
         await submitRemoteSource(form, sourceUrl);
       } else {
         await uploadFile(form, file);
       }
     } catch (err) {
-      // textContent prevents server messages from injecting HTML.
-      const errBox = document.getElementById("upload-error");
-      errBox.innerHTML = '<wa-callout variant="danger"><span></span></wa-callout>';
-      errBox.querySelector("span").textContent = err.message;
+      showError(err.message);
     } finally {
       submit.disabled = false;
     }

--- a/backend/uploader-api/app/templates/upload.html
+++ b/backend/uploader-api/app/templates/upload.html
@@ -9,6 +9,107 @@ content %}
   </wa-callout>
   {% else %}
   <form id="upload-form" class="oam-form" onsubmit="return false;">
+    <!-- Replaces the choice below when a prefill link already carries a source URL. -->
+    <div id="remote-source" hidden>
+      <wa-callout variant="neutral">
+        <strong>Imagery will be fetched for you</strong>
+        <p id="remote-source-detail"></p>
+      </wa-callout>
+    </div>
+
+    <!-- Both branches end in the same form; only the way the bytes arrive differs. -->
+    <fieldset id="source-choice" class="oam-source">
+      <legend>Where is the imagery?</legend>
+      <label class="oam-source__option">
+        <input type="radio" name="source_mode" value="file" checked />
+        <span>
+          <strong>Upload a file</strong>
+          <small>A GeoTIFF on this computer.</small>
+        </span>
+      </label>
+      <label class="oam-source__option">
+        <input type="radio" name="source_mode" value="url" />
+        <span>
+          <strong>Import from a link</strong>
+          <small>We download it for you, so you do not have to first.</small>
+        </span>
+      </label>
+    </fieldset>
+
+    <div id="file-picker" class="oam-source__panel">
+      <input type="file" id="file-input" accept=".tif,.tiff" required />
+    </div>
+
+    <div id="url-picker" class="oam-source__panel" hidden>
+      <wa-input
+        id="source-url"
+        type="url"
+        label="Link to the orthophoto"
+        placeholder="https://..."
+        hint="A public direct download. ODM all.zip links are also supported."
+      ></wa-input>
+      <!-- Filled in as the user types, when we recognise the host. -->
+      <p id="source-url-note" class="oam-source__note" hidden></p>
+
+      <wa-details summary="Where do I find that link?">
+        <div class="oam-source__help">
+          <p>
+            Any host works if the link is reachable over public HTTPS and returns the
+            <code>.tif</code> itself. Preview pages, folders and unrelated archives are
+            refused; the ODM archive case is handled below.
+          </p>
+
+          <h4>NodeODM</h4>
+          <p>
+            <code>https://your-node/task/&lt;task-uuid&gt;/download/all.zip</code>,
+            plus <code>?token=&lt;token&gt;</code> if the node was started with one. The
+            node has to be reachable from the internet. We extract only
+            <code>odm_orthophoto/odm_orthophoto.tif</code> from the archive. An old
+            <code>orthophoto.tif</code> NodeODM link is upgraded automatically.
+          </p>
+
+          <h4>WebODM</h4>
+          <p>
+            Make the task public, then paste its <code>orthophoto.tif</code> or
+            <code>all.zip</code> download URL. Private API links still need a login token
+            that OpenAerialMap does not collect.
+          </p>
+
+          <h4>ScaleODM, S3 and other object storage</h4>
+          <p>
+            Paste the presigned or public URL as it is. S3, Google Cloud Storage, Azure
+            Blob, R2, B2 and MinIO all serve the file directly, so we change nothing.
+            Start the import while the signature is still valid.
+          </p>
+
+          <h4>OneDrive and SharePoint</h4>
+          <p>
+            Share the file itself, not its folder, and copy the link. Paste it as it
+            came: we switch it to a direct download.
+          </p>
+
+          <h4>Dropbox</h4>
+          <p>Same again - share the file, copy the link, paste it as it came.</p>
+
+          <h4>Google Drive</h4>
+          <p>
+            Set access to <em>Anyone with the link</em>, copy it, and paste it as it
+            came. Drive is the least reliable of these: it sometimes shows a "can't scan
+            this file" page for a large file, which we cannot click through. If the
+            import fails, download the file and upload it instead.
+          </p>
+
+          <h4>What will not work</h4>
+          <p>
+            Private WebODM downloads, MEGA, WeTransfer and iCloud Drive need a login, a
+            POST, or in-browser decryption before any bytes appear. Download the
+            orthophoto and upload it as a file instead.
+          </p>
+        </div>
+      </wa-details>
+    </div>
+
+    <h2 class="oam-form__heading">Describe the imagery</h2>
     <wa-input name="title" label="Dataset title" required></wa-input>
     <wa-select name="platform" label="Platform type" value="uav" required>
       <wa-option value="uav">UAV / drone</wa-option>
@@ -63,21 +164,9 @@ content %}
       </wa-select>
     </wa-details>
 
-    <!-- Shown instead of the file picker when the prefill link carries a
-         source URL, naming the host the imagery will come from. -->
-    <div id="remote-source" hidden>
-      <wa-callout variant="neutral">
-        <strong>Imagery will be fetched for you</strong>
-        <p id="remote-source-detail"></p>
-      </wa-callout>
-    </div>
-
-    <div id="file-picker">
-      <input type="file" id="file-input" accept=".tif,.tiff" required />
-    </div>
     <wa-button type="submit" variant="brand" id="submit-btn">Start upload</wa-button>
 
-    <!-- Carried through from the prefill link. -->
+    <!-- From the prefill link. Hidden: a presigned URL should not reach a screenshot. -->
     <input type="hidden" name="external_id" />
     <input type="hidden" name="external_url" />
     <input type="hidden" name="source_url" />

--- a/backend/uploader-api/app/uploads/service.py
+++ b/backend/uploader-api/app/uploads/service.py
@@ -19,7 +19,7 @@ from app.auth.auth_deps import get_user_display_name, mirror_user
 from app.blocking import run_blocking
 from app.config import settings
 from app.db.models import DbUpload, UploadStatus
-from app.uploads import argo, url_guard
+from app.uploads import argo, source_links, url_guard
 from app.uploads.s3 import build_key, safe_filename
 from app.uploads.schemas import (
     CreateMultipartBody,
@@ -71,11 +71,19 @@ def _external_id_conflict(external_id: str, existing: DbUpload | None) -> HTTPEx
 
 
 async def _checked_source_url(source_url: str) -> str:
-    """Resolve and vet a caller-supplied source URL, off the event loop."""
+    """Rewrite a share link to its direct form, then resolve and vet it.
+
+    Normalising first means a share link is vetted as the host it will really be
+    fetched from. It does no I/O, so it stays on the event loop; the DNS does not.
+    """
     try:
+        direct = source_links.normalise(source_url)
+        if direct != source_url.strip():
+            # The host only: a query string is where a signature or a token is.
+            log.info("Rewrote a share link to fetch from %s", urlsplit(direct).hostname)
         return await run_blocking(
             url_guard.check_url,
-            source_url,
+            direct,
             allow_private=settings.FETCH_ALLOW_PRIVATE_HOSTS,
         )
     except url_guard.UrlRejected as err:
@@ -198,7 +206,11 @@ async def create_upload_row(
         source_url = await _checked_source_url(source_url)
         # Fall back to the URL's own basename so the archived original keeps a
         # recognisable name.
-        filename = filename or urlsplit(source_url).path
+        filename = filename or (
+            source_links.ODM_ORTHO_ASSET
+            if source_links.is_odm_archive(source_url)
+            else urlsplit(source_url).path
+        )
     filename = safe_filename(filename)
 
     upload_id = str(uuid.uuid4())

--- a/backend/uploader-api/app/uploads/source_links.py
+++ b/backend/uploader-api/app/uploads/source_links.py
@@ -1,0 +1,190 @@
+"""Rewrite share links into direct downloads, and reject those with no direct form.
+
+Runs in the API ahead of `url_guard`, so the URL we store, vet and fetch is one URL.
+Not a security control: `url_guard` vets whatever comes out, and fetch vets each
+redirect after that.
+"""
+
+import base64
+import re
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from app.uploads.url_guard import UrlRejected
+
+DRIVE_HOSTS = frozenset(
+    {"drive.google.com", "docs.google.com", "drive.usercontent.google.com"}
+)
+DRIVE_DOWNLOAD_HOST = "drive.usercontent.google.com"
+DROPBOX_HOSTS = frozenset({"www.dropbox.com", "dropbox.com"})
+ONEDRIVE_HOSTS = frozenset({"1drv.ms", "onedrive.live.com"})
+SHAREPOINT_SUFFIX = ".sharepoint.com"
+ODM_ORTHO_ASSET = "orthophoto.tif"
+ODM_ARCHIVE_ASSET = "all.zip"
+
+_DRIVE_FILE_PATH = re.compile(r"^/file/d/([A-Za-z0-9_-]+)")
+_ODM_ASSET_PATH = re.compile(r"^/task/[A-Za-z0-9_-]+/download/(?P<asset>[^/]+)$")
+_WEBODM_ASSET_PATH = re.compile(
+    r"^/api/projects/\d+/tasks/[^/]+/download/(?P<asset>[^/]+)/?$"
+)
+# SharePoint puts the share kind in the path; ":f:" is a folder, ":u:" a file.
+_SHAREPOINT_FOLDER = re.compile(r"^/:f:/")
+
+
+def _query(parts) -> dict[str, str]:
+    """Read the query as a dict; a repeated key keeps its last value."""
+    return dict(parse_qsl(parts.query, keep_blank_values=True))
+
+
+def _rebuilt(parts, host: str, path: str, query: dict[str, str]) -> str:
+    """Reassemble a URL from the pieces we changed, dropping the fragment."""
+    return urlunsplit((parts.scheme, host, path, urlencode(query), ""))
+
+
+def _drive_direct(parts) -> str:
+    """Rewrite a Drive link to the download endpoint that skips the scan page."""
+    query = _query(parts)
+    path = parts.path
+
+    if path.startswith(("/drive/folders/", "/drive/u/")):
+        raise UrlRejected(
+            "That is a link to a Google Drive folder, not a file. Open the "
+            "GeoTIFF itself, then share and copy that file's link."
+        )
+    if path.startswith(("/document/", "/spreadsheets/")):
+        raise UrlRejected("That is a Google Docs link, not a link to a file.")
+
+    matched = _DRIVE_FILE_PATH.match(path)
+    file_id = matched.group(1) if matched else query.get("id", "").strip()
+    if not file_id:
+        raise UrlRejected(
+            "Could not find a file ID in that Google Drive link. Use the link "
+            "from the file's own Share button."
+        )
+    # `confirm=t` suppresses the "can't scan this file" page for a large file.
+    direct_query = {"id": file_id, "export": "download", "confirm": "t"}
+    # Some link-shared files require this extra capability. Drive includes it
+    # in webViewLink/webContentLink, so dropping it can turn a public link into
+    # an access-denied page for a first-time visitor.
+    resource_key = query.get("resourcekey", "").strip()
+    if resource_key:
+        direct_query["resourcekey"] = resource_key
+    return _rebuilt(
+        parts,
+        DRIVE_DOWNLOAD_HOST,
+        "/download",
+        direct_query,
+    )
+
+
+def _dropbox_direct(parts) -> str:
+    """Force `dl=1` on a Dropbox share link so it serves bytes, not a page."""
+    if parts.path.startswith("/scl/fo/"):
+        raise UrlRejected(
+            "That is a link to a Dropbox folder, not a file. Share the GeoTIFF "
+            "on its own and copy that link."
+        )
+    query = _query(parts)
+    # `raw=1` does the same job, and the two together are ambiguous.
+    query.pop("raw", None)
+    query["dl"] = "1"
+    return _rebuilt(parts, parts.netloc, parts.path, query)
+
+
+def _onedrive_direct(parts) -> str:
+    """Resolve a consumer OneDrive share link through the public shares API."""
+    share = urlunsplit(parts._replace(fragment=""))
+    # Microsoft's share-ID encoding: "u!" plus unpadded base64url of the URL.
+    token = base64.urlsafe_b64encode(share.encode()).decode().rstrip("=")
+    return f"https://api.onedrive.com/v1.0/shares/u!{token}/root/content"
+
+
+def _sharepoint_direct(parts) -> str:
+    """Add `download=1` to a SharePoint or OneDrive for Business share link."""
+    if _SHAREPOINT_FOLDER.match(parts.path):
+        raise UrlRejected(
+            "That is a link to a SharePoint folder, not a file. Share the "
+            "GeoTIFF on its own and copy that link."
+        )
+    query = _query(parts)
+    query["download"] = "1"
+    return _rebuilt(parts, parts.netloc, parts.path, query)
+
+
+def _odm_asset(parts) -> str:
+    """Turn a legacy NodeODM asset link into its supported all.zip endpoint."""
+    asset = _ODM_ASSET_PATH.match(parts.path).group("asset")
+    if asset.lower() == ODM_ARCHIVE_ASSET:
+        return urlunsplit(parts._replace(fragment=""))
+    if asset.lower() == ODM_ORTHO_ASSET:
+        # NodeODM 2 removed direct asset downloads; only all.zip remains. The
+        # fetch step extracts just odm_orthophoto/odm_orthophoto.tif from it.
+        path = parts.path[: -len(asset)] + ODM_ARCHIVE_ASSET
+        return urlunsplit(parts._replace(path=path, fragment=""))
+    raise UrlRejected(
+        f"'{asset}' is not an orthophoto. Use the NodeODM '{ODM_ARCHIVE_ASSET}' "
+        "download link instead."
+    )
+
+
+def _webodm_asset(parts) -> str:
+    """Accept a public WebODM orthophoto or assets archive URL.
+
+    Private projects still return 401/403 because the fetcher deliberately does
+    not accept a WebODM login token. A public task can serve the same endpoint
+    without credentials.
+    """
+    asset = _WEBODM_ASSET_PATH.match(parts.path).group("asset")
+    if asset.lower() in (ODM_ORTHO_ASSET, ODM_ARCHIVE_ASSET):
+        return urlunsplit(parts._replace(fragment=""))
+    raise UrlRejected(
+        f"'{asset}' is not an orthophoto. Use '{ODM_ORTHO_ASSET}' or "
+        f"'{ODM_ARCHIVE_ASSET}' from the WebODM task."
+    )
+
+
+# Ordered; the first host or path that matches decides. Add a source here.
+_REWRITERS = (
+    (lambda host, path: host in DRIVE_HOSTS, _drive_direct),
+    (lambda host, path: host in DROPBOX_HOSTS, _dropbox_direct),
+    (lambda host, path: host in ONEDRIVE_HOSTS, _onedrive_direct),
+    (lambda host, path: host.endswith(SHAREPOINT_SUFFIX), _sharepoint_direct),
+    (lambda host, path: bool(_WEBODM_ASSET_PATH.match(path)), _webodm_asset),
+    (lambda host, path: bool(_ODM_ASSET_PATH.match(path)), _odm_asset),
+)
+
+
+def is_odm_archive(url: str) -> bool:
+    """Return whether a normalised URL is an ODM/WebODM all.zip download."""
+    path = urlsplit(url).path
+    node = _ODM_ASSET_PATH.match(path)
+    web = _WEBODM_ASSET_PATH.match(path)
+    matched = node or web
+    return bool(matched and matched.group("asset").lower() == ODM_ARCHIVE_ASSET)
+
+
+def normalise(url: str) -> str:
+    """Return the direct-download form of a source URL, else raise `UrlRejected`.
+
+    An unrecognised URL comes back unchanged: a presigned object-storage URL, or
+    any plain link to a file, already serves bytes and needs no help.
+    """
+    candidate = (url or "").strip()
+    if not candidate:
+        # url_guard says this better, and says it for every caller.
+        return candidate
+
+    try:
+        parts = urlsplit(candidate)
+    except ValueError:
+        # A malformed authority; url_guard is the one that reports on those.
+        return candidate
+    try:
+        host = (parts.hostname or "").lower()
+    except ValueError:
+        # A malformed authority; url_guard is the one that reports on those.
+        return candidate
+
+    for matches, rewrite in _REWRITERS:
+        if matches(host, parts.path):
+            return rewrite(parts)
+    return candidate

--- a/backend/uploader-api/app/uploads/url_guard.py
+++ b/backend/uploader-api/app/uploads/url_guard.py
@@ -43,7 +43,10 @@ def check_url(url: str, *, allow_private: bool = False, resolver=_resolve) -> st
     if len(candidate) > MAX_SOURCE_URL_LENGTH:
         raise UrlRejected("The source URL is too long.")
 
-    parts = urlsplit(candidate)._replace(fragment="")
+    try:
+        parts = urlsplit(candidate)._replace(fragment="")
+    except ValueError as err:
+        raise UrlRejected("The source URL is malformed.") from err
     try:
         parts.port
     except ValueError as err:

--- a/backend/uploader-api/pipeline/fetch/fetch.py
+++ b/backend/uploader-api/pipeline/fetch/fetch.py
@@ -21,9 +21,11 @@ fails once, immediately, with a message the uploader can read.
 import hashlib
 import logging
 import os
+import re
 import shutil
 import sys
-from urllib.parse import urljoin
+import zipfile
+from urllib.parse import urljoin, urlsplit
 
 import boto3
 import botocore.exceptions
@@ -42,6 +44,21 @@ EXIT_TRANSIENT = 75
 
 # Classic and BigTIFF, little and big endian.
 TIFF_MAGIC = (b"II*\x00", b"MM\x00*", b"II+\x00", b"MM\x00+")
+ZIP_MAGIC = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
+
+# NodeODM 2 exposes only all.zip. WebODM can expose either the TIFF itself or
+# all.zip for a public task. Archive handling is deliberately limited to these
+# URL shapes and these exact members; arbitrary ZIP URLs are still rejected.
+_NODEODM_ARCHIVE_PATH = re.compile(
+    r"^/task/[A-Za-z0-9_-]+/download/all\.zip$", re.IGNORECASE
+)
+_WEBODM_ARCHIVE_PATH = re.compile(
+    r"^/api/projects/\d+/tasks/[^/]+/download/all\.zip/?$", re.IGNORECASE
+)
+ODM_ORTHOPHOTO_MEMBERS = (
+    "odm_orthophoto/odm_orthophoto.tif",
+    "orthophoto.tif",
+)
 
 SNIFF_BYTES = 64
 CHUNK_BYTES = 1024 * 1024
@@ -72,6 +89,17 @@ def looks_like_tiff(head: bytes) -> bool:
     return head.startswith(TIFF_MAGIC)
 
 
+def looks_like_zip(head: bytes) -> bool:
+    """Return whether these first bytes have a ZIP signature."""
+    return head.startswith(ZIP_MAGIC)
+
+
+def is_odm_archive_url(url: str) -> bool:
+    """Return whether `url` is a documented NodeODM/WebODM all.zip route."""
+    path = urlsplit(url).path
+    return bool(_NODEODM_ARCHIVE_PATH.match(path) or _WEBODM_ARCHIVE_PATH.match(path))
+
+
 def clear_workspace(data_dir: str) -> None:
     """Empty the workspace without failing on what we may not delete.
 
@@ -89,17 +117,27 @@ def clear_workspace(data_dir: str) -> None:
             log.info("fetch: leaving %s in place (%s)", path, err)
 
 
-def _stream_to_file(response: httpx.Response, dest: str, max_bytes: int) -> int:
-    """Write a response body to disk, checking the first bytes and the size."""
+def _stream_to_file(
+    response: httpx.Response,
+    dest: str,
+    max_bytes: int,
+    *,
+    expected: str = "tiff",
+) -> int:
+    """Write a response body to disk, checking its magic and size."""
     written = 0
     head = b""
+    expected_magic = looks_like_zip if expected == "zip" else looks_like_tiff
     with open(dest, "wb") as out:
         for chunk in response.iter_bytes(CHUNK_BYTES):
             if len(head) < SNIFF_BYTES:
                 head = (head + chunk)[:SNIFF_BYTES]
-                if len(head) >= 4 and not looks_like_tiff(head):
+                if len(head) >= 4 and not expected_magic(head):
+                    label = (
+                        "an ODM assets archive" if expected == "zip" else "a GeoTIFF"
+                    )
                     raise FetchError(
-                        "The source URL did not return a GeoTIFF. Link straight "
+                        f"The source URL did not return {label}. Link straight "
                         "to the file rather than to a preview or download page."
                     )
             written += len(chunk)
@@ -110,8 +148,9 @@ def _stream_to_file(response: httpx.Response, dest: str, max_bytes: int) -> int:
             out.write(chunk)
     if written == 0:
         raise FetchError("The source URL returned no data.")
-    if not looks_like_tiff(head):
-        raise FetchError("The source URL did not return a GeoTIFF.")
+    if not expected_magic(head):
+        label = "an ODM assets archive" if expected == "zip" else "a GeoTIFF"
+        raise FetchError(f"The source URL did not return {label}.")
     return written
 
 
@@ -123,6 +162,7 @@ def download(
     max_bytes: int,
     allow_private: bool = False,
     max_redirects: int = url_guard.MAX_REDIRECTS,
+    expected: str = "tiff",
 ) -> int:
     """Fetch a source URL to `dest`, rechecking every redirect it follows.
 
@@ -161,7 +201,7 @@ def download(
                 )
             log.info("fetch: downloading from %s", redacted(url))
             try:
-                return _stream_to_file(response, dest, max_bytes)
+                return _stream_to_file(response, dest, max_bytes, expected=expected)
             except httpx.TransportError as err:
                 raise FetchError(
                     f"The transfer failed part way through ({err}).", transient=True
@@ -170,6 +210,60 @@ def download(
             response.close()
 
     raise FetchError("The source URL redirected too many times.")
+
+
+def extract_odm_orthophoto(archive: str, dest: str, max_bytes: int) -> int:
+    """Extract only ODM's orthophoto from all.zip, without extracting paths.
+
+    Reading one named member avoids path traversal and ignores every sidecar or
+    unrelated asset. The member gets the same byte ceiling and TIFF sniff as a
+    direct download, so compression cannot bypass either guard.
+    """
+    try:
+        with zipfile.ZipFile(archive) as zipped:
+            member = next(
+                (name for name in ODM_ORTHOPHOTO_MEMBERS if name in zipped.NameToInfo),
+                None,
+            )
+            if member is None:
+                raise FetchError(
+                    "The ODM assets archive does not contain an orthophoto GeoTIFF."
+                )
+            info = zipped.getinfo(member)
+            if info.flag_bits & 0x1:
+                raise FetchError("The orthophoto in the ODM archive is encrypted.")
+            if info.compress_type not in (zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED):
+                raise FetchError(
+                    "The ODM archive uses an unsupported compression method."
+                )
+            if info.file_size > max_bytes:
+                raise FetchError(
+                    f"The orthophoto is larger than the {max_bytes}-byte limit."
+                )
+
+            written = 0
+            head = b""
+            with zipped.open(info) as source, open(dest, "wb") as out:
+                for chunk in iter(lambda: source.read(CHUNK_BYTES), b""):
+                    if len(head) < SNIFF_BYTES:
+                        head = (head + chunk)[:SNIFF_BYTES]
+                        if len(head) >= 4 and not looks_like_tiff(head):
+                            raise FetchError(
+                                "The orthophoto in the ODM archive is not a GeoTIFF."
+                            )
+                    written += len(chunk)
+                    if written > max_bytes:
+                        raise FetchError(
+                            f"The orthophoto is larger than the {max_bytes}-byte limit."
+                        )
+                    out.write(chunk)
+            if not looks_like_tiff(head):
+                raise FetchError("The orthophoto in the ODM archive is not a GeoTIFF.")
+            return written
+    except zipfile.BadZipFile as err:
+        raise FetchError(
+            "The source URL returned a damaged ODM assets archive."
+        ) from err
 
 
 class _Progress:
@@ -293,6 +387,8 @@ def _fetch_from_url(
     s3, url: str, *, dest: str, bucket: str, key: str, max_bytes: int
 ) -> None:
     """Download the caller's source URL and archive the bytes we accepted."""
+    archive_source = is_odm_archive_url(url)
+    download_dest = f"{dest}.zip" if archive_source else dest
     with httpx.Client(
         timeout=httpx.Timeout(READ_TIMEOUT_SECONDS, connect=CONNECT_TIMEOUT_SECONDS),
         trust_env=False,
@@ -300,12 +396,22 @@ def _fetch_from_url(
     ) as fetcher:
         size = download(
             url,
-            dest,
+            download_dest,
             client=fetcher,
             max_bytes=max_bytes,
             allow_private=_env_flag("ALLOW_PRIVATE_HOSTS"),
+            expected="zip" if archive_source else "tiff",
         )
     log.info("fetch: retrieved %s bytes", size)
+    if archive_source:
+        try:
+            size = extract_odm_orthophoto(download_dest, dest, max_bytes)
+        finally:
+            try:
+                os.unlink(download_dest)
+            except FileNotFoundError:
+                pass
+        log.info("fetch: extracted %s orthophoto bytes from the ODM archive", size)
     # Archive under this upload's key, and only now that the bytes have been
     # checked: this bucket is world-readable.
     log.info("fetch: archiving the original")

--- a/backend/uploader-api/pipeline/fetch/tests/test_fetch.py
+++ b/backend/uploader-api/pipeline/fetch/tests/test_fetch.py
@@ -7,16 +7,38 @@ redirect goes back through those rules instead of being followed blindly.
 """
 
 import http.server
+import io
 import threading
+import zipfile
+from pathlib import Path
 
 import httpx
 import pytest
 import url_guard
-from fetch import FetchError, clear_workspace, download, looks_like_tiff, redacted
+from fetch import (
+    FetchError,
+    _fetch_from_url,
+    clear_workspace,
+    download,
+    extract_odm_orthophoto,
+    is_odm_archive_url,
+    looks_like_tiff,
+    redacted,
+)
 
 TIFF = b"II*\x00" + bytes(2048)
 BIG_TIFF_CHUNK = b"II+\x00" + bytes(1024 * 1024)
 HTML = b"<!DOCTYPE html><html><body>Sign in to download this file</body></html>"
+
+
+def _archive(member="odm_orthophoto/odm_orthophoto.tif", content=TIFF):
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as zipped:
+        zipped.writestr(member, content)
+    return output.getvalue()
+
+
+ODM_ARCHIVE = _archive()
 
 
 class _Handler(http.server.BaseHTTPRequestHandler):
@@ -39,6 +61,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         routes = {
             "/tif": lambda: self._send(200, TIFF),
             "/html": lambda: self._send(200, HTML),
+            "/all.zip": lambda: self._send(200, ODM_ARCHIVE),
+            "/task/abc/download/all.zip": lambda: self._send(200, ODM_ARCHIVE),
             "/empty": lambda: self._send(200, b""),
             "/redirect": lambda: self._send(302, headers=[("Location", "/tif")]),
             "/relative": lambda: self._send(302, headers=[("Location", "tif")]),
@@ -100,6 +124,13 @@ def _download(server, client, tmp_path, path, **kwargs):
 def test_downloads_a_geotiff(server, client, tmp_path, path):
     assert _download(server, client, tmp_path, path) == len(TIFF)
     assert (tmp_path / "out.tif").read_bytes() == TIFF
+
+
+def test_downloads_an_expected_odm_archive(server, client, tmp_path):
+    assert _download(server, client, tmp_path, "/all.zip", expected="zip") == len(
+        ODM_ARCHIVE
+    )
+    assert (tmp_path / "out.tif").read_bytes() == ODM_ARCHIVE
 
 
 @pytest.mark.parametrize("path", ["/to-file", "/to-credentials"])
@@ -175,6 +206,85 @@ def test_accepts_every_tiff_flavour(head):
 @pytest.mark.parametrize("head", [b"<!DOCTYPE", b"\x89PNG", b"PK\x03\x04", b""])
 def test_rejects_everything_else(head):
     assert not looks_like_tiff(head)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://node.example/task/abc/download/all.zip?token=secret",
+        "https://webodm.example/api/projects/1/tasks/abc/download/all.zip/",
+    ],
+)
+def test_recognises_only_odm_archive_routes(url):
+    assert is_odm_archive_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example/all.zip",
+        "https://node.example/task/abc/download/orthophoto.tif",
+        "https://webodm.example/api/projects/1/tasks/abc/download/textured.zip",
+    ],
+)
+def test_does_not_extract_arbitrary_archive_urls(url):
+    assert not is_odm_archive_url(url)
+
+
+def test_extracts_only_the_odm_orthophoto(tmp_path):
+    archive = tmp_path / "all.zip"
+    archive.write_bytes(ODM_ARCHIVE)
+    dest = tmp_path / "input.tif"
+    assert extract_odm_orthophoto(str(archive), str(dest), len(TIFF)) == len(TIFF)
+    assert dest.read_bytes() == TIFF
+
+
+def test_nodeodm_archive_flow_stores_only_the_extracted_tiff(
+    server, tmp_path, monkeypatch
+):
+    class _S3:
+        uploaded = b""
+
+        def upload_file(self, source, bucket, key, ExtraArgs):
+            self.uploaded = Path(source).read_bytes()
+            assert (bucket, key) == ("oam", "user/id/orthophoto.tif")
+            assert ExtraArgs == {"ContentType": "image/tiff"}
+
+    monkeypatch.setenv("ALLOW_PRIVATE_HOSTS", "true")
+    s3 = _S3()
+    dest = tmp_path / "input.tif"
+    _fetch_from_url(
+        s3,
+        f"{server}/task/abc/download/all.zip",
+        dest=str(dest),
+        bucket="oam",
+        key="user/id/orthophoto.tif",
+        max_bytes=1024**2,
+    )
+    assert dest.read_bytes() == TIFF
+    assert s3.uploaded == TIFF
+    assert not (tmp_path / "input.tif.zip").exists()
+
+
+@pytest.mark.parametrize(
+    ("member", "content", "message"),
+    [
+        ("etc/passwd", TIFF, "does not contain"),
+        ("odm_orthophoto/odm_orthophoto.tif", HTML, "not a GeoTIFF"),
+    ],
+)
+def test_rejects_an_unsafe_or_wrong_archive(tmp_path, member, content, message):
+    archive = tmp_path / "all.zip"
+    archive.write_bytes(_archive(member, content))
+    with pytest.raises(FetchError, match=message):
+        extract_odm_orthophoto(str(archive), str(tmp_path / "out.tif"), 1024**2)
+
+
+def test_archive_member_cannot_expand_past_the_limit(tmp_path):
+    archive = tmp_path / "all.zip"
+    archive.write_bytes(_archive(content=TIFF + bytes(4096)))
+    with pytest.raises(FetchError, match="larger than"):
+        extract_odm_orthophoto(str(archive), str(tmp_path / "out.tif"), len(TIFF))
 
 
 def test_keeps_signatures_out_of_the_logs():

--- a/backend/uploader-api/pipeline/workflow-template.yaml
+++ b/backend/uploader-api/pipeline/workflow-template.yaml
@@ -182,7 +182,8 @@ spec:
     # where an upload came from - and the only one that talks to an address the
     # uploader chose. See pipeline/fetch/fetch.py for what it will and will not
     # fetch; the short version is https, no credentials, public addresses only,
-    # rechecked on every redirect, and TIFF bytes or nothing.
+    # rechecked on every redirect, and TIFF bytes or a narrowly handled ODM
+    # all.zip archive containing that TIFF.
     - name: fetch-source
       container:
         image: ghcr.io/hotosm/openaerialmap/uploader/fetch:{{workflow.parameters.image-tag}}

--- a/backend/uploader-api/tests/test_source_links.py
+++ b/backend/uploader-api/tests/test_source_links.py
@@ -1,0 +1,215 @@
+"""Rewriting share links into something the fetch step can download."""
+
+import base64
+
+import pytest
+from litestar.exceptions import HTTPException
+
+from app.uploads import service
+from app.uploads.source_links import is_odm_archive, normalise
+from app.uploads.url_guard import UrlRejected
+
+DRIVE_DIRECT = (
+    "https://drive.usercontent.google.com/download"
+    "?id=1AbC_dEf-123&export=download&confirm=t"
+)
+NODEODM_ARCHIVE = "https://node.example.org/task/9f8e7d6c/download/all.zip"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://drive.google.com/file/d/1AbC_dEf-123/view?usp=sharing",
+        "https://drive.google.com/file/d/1AbC_dEf-123/edit",
+        "https://drive.google.com/open?id=1AbC_dEf-123",
+        "https://drive.google.com/uc?export=download&id=1AbC_dEf-123",
+        # Already on the download endpoint, but without the confirm that gets
+        # a large file past the virus-scan page.
+        "https://drive.usercontent.google.com/download?id=1AbC_dEf-123",
+    ],
+)
+def test_drive_links_become_the_download_endpoint(url):
+    assert normalise(url) == DRIVE_DIRECT
+
+
+def test_a_drive_resource_key_survives_the_rewrite():
+    assert (
+        normalise(
+            "https://drive.google.com/file/d/1AbC_dEf-123/view?resourcekey=0-secret"
+        )
+        == f"{DRIVE_DIRECT}&resourcekey=0-secret"
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://drive.google.com/drive/folders/1AbC_dEf-123",
+        "https://drive.google.com/drive/u/0/my-drive",
+        "https://docs.google.com/document/d/1AbC_dEf-123/edit",
+        # No file ID to work with.
+        "https://drive.google.com/file/d//view",
+        "https://drive.google.com/",
+    ],
+)
+def test_drive_links_we_cannot_use_are_named_as_such(url):
+    with pytest.raises(UrlRejected):
+        normalise(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.dropbox.com/scl/fi/abc123/ortho.tif?rlkey=xyz&dl=0",
+        "https://www.dropbox.com/scl/fi/abc123/ortho.tif?rlkey=xyz&dl=1",
+        # `raw=1` does the same job; the two together are ambiguous.
+        "https://www.dropbox.com/scl/fi/abc123/ortho.tif?rlkey=xyz&raw=1",
+        "https://www.dropbox.com/scl/fi/abc123/ortho.tif?rlkey=xyz",
+    ],
+)
+def test_a_dropbox_link_is_forced_to_a_direct_download(url):
+    result = normalise(url)
+    assert result.startswith("https://www.dropbox.com/scl/fi/abc123/ortho.tif?")
+    assert "dl=1" in result
+    assert "raw=" not in result
+    assert "rlkey=xyz" in result
+
+
+def test_a_dropbox_folder_is_refused():
+    with pytest.raises(UrlRejected, match="folder"):
+        normalise("https://www.dropbox.com/scl/fo/abc123/AAA?rlkey=xyz&dl=0")
+
+
+def test_a_dropbox_content_host_link_is_left_alone():
+    """Already the direct form; nothing to fix."""
+    url = "https://uc123.dl.dropboxusercontent.com/cd/0/get/abc/ortho.tif"
+    assert normalise(url) == url
+
+
+def test_a_consumer_onedrive_link_goes_through_the_shares_api():
+    share = "https://1drv.ms/u/s!AbCdEf-123"
+    token = base64.urlsafe_b64encode(share.encode()).decode().rstrip("=")
+    assert normalise(share) == (
+        f"https://api.onedrive.com/v1.0/shares/u!{token}/root/content"
+    )
+    assert "=" not in normalise(share).split("u!")[1].split("/")[0]
+
+
+def test_a_sharepoint_file_link_is_given_download_1():
+    result = normalise(
+        "https://contoso-my.sharepoint.com/:u:/g/personal/sam/AbC123?e=xYz"
+    )
+    assert result.startswith(
+        "https://contoso-my.sharepoint.com/:u:/g/personal/sam/AbC123?"
+    )
+    assert "download=1" in result
+    # The share token has to survive, or the link stops resolving.
+    assert "e=xYz" in result
+
+
+def test_a_sharepoint_folder_is_refused():
+    with pytest.raises(UrlRejected, match="folder"):
+        normalise("https://contoso.sharepoint.com/:f:/g/personal/sam/AbC123")
+
+
+def test_a_legacy_nodeodm_orthophoto_link_becomes_the_assets_archive():
+    url = "https://node.example.org/task/9f8e7d6c/download/orthophoto.tif?token=secret"
+    assert normalise(url) == f"{NODEODM_ARCHIVE}?token=secret"
+
+
+def test_a_nodeodm_archive_link_passes_through_with_its_token():
+    assert normalise(f"{NODEODM_ARCHIVE}?token=secret") == (
+        f"{NODEODM_ARCHIVE}?token=secret"
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        NODEODM_ARCHIVE,
+        "https://webodm.example/api/projects/7/tasks/abc/download/all.zip/",
+    ],
+)
+def test_odm_archives_are_identified_for_a_tiff_storage_name(url):
+    assert is_odm_archive(url)
+
+
+def test_a_direct_orthophoto_is_not_misnamed_as_an_archive():
+    assert not is_odm_archive(
+        "https://webodm.example/api/projects/7/tasks/abc/download/orthophoto.tif"
+    )
+
+
+@pytest.mark.parametrize(
+    ("asset", "expected"),
+    [
+        ("georeferenced_model.laz", "not an orthophoto"),
+        ("orthophoto.png", "not an orthophoto"),
+    ],
+)
+def test_other_odm_assets_point_at_the_orthophoto_instead(asset, expected):
+    with pytest.raises(UrlRejected, match=expected):
+        normalise(f"https://node.example.org/task/9f8e7d6c/download/{asset}")
+
+
+@pytest.mark.parametrize("asset", ["orthophoto.tif", "all.zip"])
+def test_a_public_webodm_download_link_is_accepted(asset):
+    url = f"https://webodm.example.org/api/projects/7/tasks/abc/download/{asset}"
+    assert normalise(url) == url
+
+
+def test_an_unrelated_webodm_asset_is_refused():
+    with pytest.raises(UrlRejected, match="not an orthophoto"):
+        normalise(
+            "https://webodm.example.org/api/projects/7/tasks/abc/download/"
+            "textured_model.zip"
+        )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # Object storage already serves bytes; a rewrite could only break the
+        # signature. This is the ScaleODM path, and S3-compatible generally.
+        "https://bucket.s3.eu-west-1.amazonaws.com/ortho.tif"
+        "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc&X-Amz-Expires=900",
+        "https://storage.googleapis.com/bucket/ortho.tif"
+        "?X-Goog-Signature=abc&X-Goog-Expires=900",
+        "https://acct.blob.core.windows.net/c/ortho.tif?sv=2024-11-04&sig=abc",
+        "https://acct.r2.cloudflarestorage.com/bucket/ortho.tif?X-Amz-Signature=abc",
+        "https://s3.us-west-000.backblazeb2.com/bucket/ortho.tif",
+        "https://minio.example.org/bucket/ortho.tif",
+        "https://imagery.example.org/ortho.tif",
+        # url_guard rejects these; normalising is not the place to duplicate it.
+        "http://imagery.example.org/ortho.tif",
+        "not a url at all",
+        "https://[not-an-ipv6-address/ortho.tif",
+        "",
+        "   ",
+    ],
+)
+def test_an_unrecognised_url_is_returned_as_it_came(url):
+    assert normalise(url) == url.strip()
+
+
+@pytest.mark.asyncio
+async def test_the_api_vets_the_rewritten_url_not_the_pasted_one(monkeypatch):
+    """The stored URL and the checked URL have to be the same one."""
+    seen = []
+    monkeypatch.setattr(
+        service.url_guard, "check_url", lambda url, **kw: seen.append(url) or url
+    )
+
+    stored = await service._checked_source_url(
+        "  https://drive.google.com/file/d/1AbC_dEf-123/view?usp=sharing  "
+    )
+    assert seen == [DRIVE_DIRECT]
+    assert stored == DRIVE_DIRECT
+
+    # And a link with no direct form never reaches the guard at all.
+    seen.clear()
+    with pytest.raises(HTTPException, match="folder"):
+        await service._checked_source_url(
+            "https://www.dropbox.com/scl/fo/abc123/AAA?dl=0"
+        )
+    assert seen == []

--- a/backend/uploader-api/tests/test_url_guard.py
+++ b/backend/uploader-api/tests/test_url_guard.py
@@ -18,6 +18,7 @@ PUBLIC = ["93.184.216.34"]
         "http://example.org/a.tif",  # plaintext
         "https://user:pass@example.org/a.tif",
         "https:///a.tif",
+        "https://[not-an-ipv6-address/a.tif",
         "https://example.org:notaport/a.tif",
         "https://example.org/" + "a" * MAX_SOURCE_URL_LENGTH,
     ],

--- a/docs/dev/backend/stactools-hotosm.md
+++ b/docs/dev/backend/stactools-hotosm.md
@@ -88,12 +88,18 @@ run every 30 minutes, consider running with `--uploaded-since=2100`
 Every Item we create lists the OAM STAC extension in `stac_extensions`:
 
 ```text
-https://docs.imagery.hotosm.org/oam/v0.1.0/schema.json
+https://docs.imagery.hotosm.org/oam/v0.2.0/schema.json
 ```
 
-That URL is this site. `docs/oam/v0.1.0/schema.json` is a symlink to
+That URL is this site. `docs/oam/v0.2.0/schema.json` is a symlink to
 `backend/stactools-hotosm/stac-extension/json-schema/schema.json`, which is the
-source of truth, so publishing a schema change is just a push to `main`.
+source of truth for the current version, so publishing a schema change is just
+a push to `main`.
+
+Older versions stay published at their own URL with their original definition,
+so Items created before v0.2.0 keep validating unchanged. See the package
+[README](https://github.com/hotosm/openaerialmap/blob/main/backend/stactools-hotosm/README.md)
+for how to create a new version.
 
 Validation during Item creation does not fetch it - the same schema is shipped
 inside the package and registered with `pystac` before `Item.validate()`, so

--- a/docs/dev/new-provider.md
+++ b/docs/dev/new-provider.md
@@ -25,3 +25,79 @@ that syncs your data on a schedule.
 See
 [sync-maxar](https://github.com/hotosm/k8s-infra/blob/main/kubernetes/manifests/sync-maxar.yaml)
 for a representative example.
+
+## STAC Metadata
+
+Items are read by the browse map, the tile server, and the STAC API
+search. The tables below separate out **mandatory** from **optional**
+fields.
+
+<!-- markdownlint-disable MD013 -->
+
+### Required
+
+Leave one out and the item is rejected, invisible on the map, or undisplayable.
+
+| Field                          | What to put in it                                                                                                                                                                      | What needs it                                                                                                                                        |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                           | A unique name. Don't use `/` in it                                                                                                                                                     | Item lookups in the API break on slashes - swap them for `-`                                                                                         |
+| `geometry`                     | The image outline as GeoJSON, in lat/lon (EPSG:4326)                                                                                                                                   | The shape drawn on the browse map                                                                                                                    |
+| `bbox`                         | `[west, south, east, north]` of that outline                                                                                                                                           | "What imagery is in this area?" search                                                                                                               |
+| `stac_extensions`              | Must include `https://docs.imagery.hotosm.org/oam/v0.2.0/schema.json`                                                                                                                  | Marks the item as OAM imagery, and turns on validation of the `oam:` fields below                                                                    |
+| `properties.datetime`          | When the image was taken                                                                                                                                                               | The card, and the date filter. For a capture period, set it to `null` and give `start_datetime` / `end_datetime` - but the key must still be present |
+| `properties.title`             | A human-readable name                                                                                                                                                                  | Card and sidebar heading                                                                                                                             |
+| `properties.gsd`               | Pixel size on the ground, in metres                                                                                                                                                    | The resolution filter. Imagery without it is hidden whenever that filter is used                                                                     |
+| `properties.oam:platform_type` | One of `kite`, `balloon`, `uav`, `aircraft`, `satellite`                                                                                                                               | The platform filter (drone / aircraft / satellite)                                                                                                   |
+| `properties.oam:producer_name` | **Name** of the organisation or person who made the imagery, e.g. `Maxar`. Not an email address                                                                                        | Attribution. Must match the first `providers` entry                                                                                                  |
+| `properties.license`           | One of `CC-BY-4.0`, `CC-BY-SA-4.0`, `CC-BY-NC-4.0`                                                                                                                                     | The license filter. OAM only hosts open imagery, so anything else is rejected                                                                        |
+| `providers`                    | Producer first, with `name` (same as `oam:producer_name`), `roles: ["producer", "licensor"]`, and the **contact** in `description` - an email, or a team name if none can be published | Cards show `providers[0].name`; `description` is how people get in touch                                                                             |
+| `assets.visual`                | Link to the imagery as a Cloud Optimized GeoTIFF (COG). Must be named `visual`                                                                                                         | The tile server draws from it, and it's the card's download link                                                                                     |
+| `assets.thumbnail`             | Link to a small PNG preview                                                                                                                                                            | The browse card picture. Items still work without one, but the card is blank                                                                         |
+
+!!! tip "Imagery that crosses the date line"
+
+    Split the `geometry` into two polygons either side of the 180° meridian,
+    and write the `bbox` west edge first even though it's the bigger number
+    (e.g. `[179.5, -16, -179.5, -15]`) - that's how a reader knows it wraps.
+    Otherwise the item draws as a stripe across the whole map.
+
+### Optional
+
+The uploader works these out from the image file. An ingested catalogue
+usually won't have them and OAM copes without, so fill in what your source
+provides and skip the rest.
+
+| Field                                        | What it is                                                                               | What you get for it                                                                                    |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `properties.start_datetime` / `end_datetime` | Start and end of capture                                                                 | Shows a date range instead of a single moment                                                          |
+| `properties.created`                         | When the item was added to OAM                                                           | Tells "added recently" apart from "photographed recently"                                              |
+| `properties.instruments`                     | Camera or sensor name, as a list                                                         | Sensor shown on the card                                                                               |
+| `properties.renders`                         | Display hints: which bands, how to stretch them, which colour ramp, what counts as empty | Makes non-photo imagery (elevation, radar, multispectral) viewable. Without it the map shows raw bands |
+| `properties.oam:product_type`                | `visual`, `multispectral`, `sar`, `elevation` or `pseudocolor`                           | Picks the display hints above. Guessed from the file when not given                                    |
+| `properties.oam:product_type_source`         | `declared` if a person set the type, `detected` if it was guessed                        | Says how much to trust the type                                                                        |
+| `properties.oam:footprint_source`            | `mask` if the outline follows the real image edge, `bbox` if it's just the rectangle     | Says how tight the outline on the map is                                                               |
+| `properties.oam:footprint_area`              | Covered area in square metres                                                            | Coverage stats                                                                                         |
+| `properties.oam:acquisition_time_estimated`  | `true` when nobody supplied a capture date                                               | Warns that the date is a best guess                                                                    |
+| `properties.oam:acquisition_source`          | Where the guessed date came from: `file-tags` or `ingest`                                | Says how good that guess is                                                                            |
+| `properties.oam:external_id`                 | An ID from the system that sent the imagery, e.g. an ODM task                            | Links the item back to that system                                                                     |
+| `properties.processing:*`                    | `software`, `version`, `lineage`, `datetime` - what produced the file and how            | Provenance                                                                                             |
+| `assets.visual.file:size`                    | File size in bytes                                                                       | Download size on the card                                                                              |
+| `assets.visual.file:checksum`                | Checksum of the file                                                                     | Lets anyone confirm the download wasn't corrupted                                                      |
+| `assets.visual.bands`                        | Band names, with `eo:common_name` where known (`red`, `nir`, ...)                        | Lets OAM pick sensible red/green/blue bands for display                                                |
+| `assets.visual.proj:*`                       | Native projection, image size, transform                                                 | Saves tools from opening the file to find out                                                          |
+| `assets.original`                            | Link to the untouched original file                                                      | Archival, in case the converted copy is ever wrong                                                     |
+| `assets.metadata`                            | Link to the item's own JSON                                                              | A stable copy of the record                                                                            |
+| `assets.tms` / `assets.wmts`                 | Link to an existing tile service                                                         | Used instead of OAM's tile server (older OAM items)                                                    |
+| `assets.*.alternate`                         | A second link to the same file, usually `s3://`                                          | Direct bucket access for people who prefer it                                                          |
+| `links[rel=derived-from]`                    | Link to the original item in your catalogue                                              | Provenance for ingested imagery - worth adding for any third-party source                              |
+| `links[rel=via]`                             | Link to a public page about the imagery                                                  | A "more info" backlink                                                                                 |
+
+<!-- markdownlint-enable MD013 -->
+
+!!! note "Extension versions"
+
+    Every `oam:` field here is defined in OAM extension **v0.2.0**. Older items
+    list v0.1.0, which knows only `oam:platform_type` and `oam:producer_name`
+    and rejects any other `oam:` field; that URL still serves the old
+    definition, so those items keep validating. Point new items at v0.2.0, and
+    add any `oam:` field of your own to the schema before using it.

--- a/docs/oam/v0.1.0/schema.json
+++ b/docs/oam/v0.1.0/schema.json
@@ -1,1 +1,1 @@
-../../../backend/stactools-hotosm/stac-extension/json-schema/schema.json
+../../../backend/stactools-hotosm/src/stactools/hotosm/schemas/oam/v0.1.0/schema.json

--- a/docs/oam/v0.2.0/schema.json
+++ b/docs/oam/v0.2.0/schema.json
@@ -1,0 +1,1 @@
+../../../backend/stactools-hotosm/stac-extension/json-schema/schema.json

--- a/notebooks/pyproject.toml
+++ b/notebooks/pyproject.toml
@@ -22,3 +22,5 @@ dev = ["ruff>=0.11.11"]
 # Important to skip intentional misspelling checks! E.g. API has both 'unknown' and 'unknow'
 skip = "notebooks/*,*pnpm-lock.yaml,*package-lock.json,*CHANGELOG.md,*/tests/data/*"
 write-changes = true
+# For uploader-api
+ignore-words-list = "fo"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Related to #295

## Describe this PR

- Added uploader-api with a few extra `oam:xxx` metadata fields in STAC, generated on upload.
- We need to publish this new schema with details.

## Checklist before requesting a review

- 📖 Read the OAM Contributing Guide: <https://github.com/hotosm/openaerialmap/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
