### PR TITLE
feat(tilepack): add first-pass OGC process API

### DIFF
--- a/backend/tilepack-api/README.md
+++ b/backend/tilepack-api/README.md
@@ -30,13 +30,36 @@ once complete.
 ## API Surface
 
 ```text
+GET  /processes
+GET  /processes/{processId}
+POST /processes/{processId}/execution
 POST /tilepacks/{stac_item_id}?format=pmtiles|mbtiles[&min_zoom=N&max_zoom=N]
 GET  /healthz
 ```
 
+The `/processes` routes are a minimal, OGC-compatible façade around the
+existing tilepack implementation. This is intentionally the first tilepack
+process and not a complete OGC Processes catalog for the wider OAM platform.
+The tilepack service currently owns the `tilepack` process namespace; future
+multi-service `/processes` integration should decide exact route ownership via
+ingress/Gateway matching rather than by assuming a single global process index.
+
 The only user input is a STAC item id (regex-validated, max 128 chars,
 must exist in the configured `openaerialmap` STAC collection) and the
 output format.
+
+### Process discovery and execution
+
+```http
+GET /processes
+GET /processes/tilepack
+POST /processes/tilepack/execution?id=67ac...&format=pmtiles
+```
+
+The process description advertises the current supported tilepack inputs and
+outputs based on the real API behavior. Execution reuses the same validation,
+idempotent S3 lock/output checks, Kubernetes Job creation, and pgSTAC update
+sequence as the legacy `/tilepacks/{id}` endpoint.
 
 Zoom behavior has two modes:
 

--- a/backend/tilepack-api/chart/templates/ingress.yaml
+++ b/backend/tilepack-api/chart/templates/ingress.yaml
@@ -36,6 +36,13 @@ spec:
                 name: {{ include "chart.fullname" . }}
                 port:
                   number: {{ .Values.service.port }}
+          - path: /processes
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "chart.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
           - path: /healthz
             pathType: Exact
             backend:

--- a/backend/tilepack-api/internal/handler/handler.go
+++ b/backend/tilepack-api/internal/handler/handler.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"math"
 	"net"
@@ -56,6 +57,9 @@ func (h *Handler) Routes() http.Handler {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
+	mux.HandleFunc("GET /processes", h.getProcesses)
+	mux.HandleFunc("GET /processes/{processID}", h.getProcess)
+	mux.HandleFunc("POST /processes/{processID}/execution", h.postProcessExecution)
 	mux.HandleFunc("POST /tilepacks/{id}", h.postTilepack)
 	// Preflight for browser CORS requests to the public trigger
 	// endpoint. Response headers are added by corsMiddleware.
@@ -151,6 +155,148 @@ type response struct {
 	Message    string `json:"message,omitempty"`
 }
 
+type processDescription struct {
+	ID               string         `json:"id"`
+	Title            string         `json:"title"`
+	Description      string         `json:"description"`
+	Version          string         `json:"version,omitempty"`
+	JobControlOptions []string      `json:"jobControlOptions,omitempty"`
+	OutputTransmission []string     `json:"outputTransmission,omitempty"`
+	Keywords         []string       `json:"keywords,omitempty"`
+	Inputs           map[string]any `json:"inputs,omitempty"`
+	Outputs          map[string]any `json:"outputs,omitempty"`
+	Links            []map[string]any `json:"links,omitempty"`
+}
+
+type processListResponse struct {
+	Processes []processDescription `json:"processes"`
+}
+
+const tilepackProcessID = "tilepack"
+
+func (h *Handler) getProcesses(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, processListResponse{Processes: []processDescription{tilepackProcessDescription()}})
+}
+
+func (h *Handler) getProcess(w http.ResponseWriter, r *http.Request) {
+	if r.PathValue("processID") != tilepackProcessID {
+		writeJSON(w, http.StatusNotFound, response{Status: "error", Message: "process not found"})
+		return
+	}
+	writeJSON(w, http.StatusOK, tilepackProcessDescription())
+}
+
+func (h *Handler) postProcessExecution(w http.ResponseWriter, r *http.Request) {
+	if r.PathValue("processID") != tilepackProcessID {
+		writeJSON(w, http.StatusNotFound, response{Status: "error", Message: "process not found"})
+		return
+	}
+	id, format, minZoomQ, maxZoomQ, err := parseProcessExecutionInputs(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, response{Status: "error", Message: err.Error()})
+		return
+	}
+	h.handleTilepackRequest(w, r, id, format, minZoomQ, maxZoomQ)
+}
+
+func parseProcessExecutionInputs(r *http.Request) (string, string, string, string, error) {
+	query := r.URL.Query()
+	id := query.Get("id")
+	if id == "" {
+		id = query.Get("item_id")
+	}
+	format := strings.ToLower(query.Get("format"))
+	minZoomQ := query.Get("min_zoom")
+	maxZoomQ := query.Get("max_zoom")
+
+	if r.Body != nil && r.ContentLength != 0 {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			return "", "", "", "", errors.New("invalid JSON body")
+		}
+		if v, ok := body["id"]; ok && id == "" {
+			if s, ok := v.(string); ok {
+				id = s
+			}
+		}
+		if inputs, ok := body["inputs"].(map[string]any); ok {
+			if v, ok := inputs["id"]; ok && id == "" {
+				if s, ok := v.(string); ok {
+					id = s
+				}
+			}
+			if v, ok := inputs["format"]; ok && format == "" {
+				if s, ok := v.(string); ok {
+					format = strings.ToLower(s)
+				}
+			}
+			if v, ok := inputs["min_zoom"]; ok && minZoomQ == "" {
+				minZoomQ = fmt.Sprint(v)
+			}
+			if v, ok := inputs["max_zoom"]; ok && maxZoomQ == "" {
+				maxZoomQ = fmt.Sprint(v)
+			}
+		}
+		if v, ok := body["format"]; ok && format == "" {
+			if s, ok := v.(string); ok {
+				format = strings.ToLower(s)
+			}
+		}
+		if v, ok := body["min_zoom"]; ok && minZoomQ == "" {
+			minZoomQ = fmt.Sprint(v)
+		}
+		if v, ok := body["max_zoom"]; ok && maxZoomQ == "" {
+			maxZoomQ = fmt.Sprint(v)
+		}
+	}
+	if id == "" {
+		return "", "", "", "", errors.New("stac item id is required")
+	}
+	if format == "" {
+		return "", "", "", "", errors.New("format must be pmtiles or mbtiles")
+	}
+	return id, strings.ToLower(format), minZoomQ, maxZoomQ, nil
+}
+
+func tilepackProcessDescription() processDescription {
+	return processDescription{
+		ID:          tilepackProcessID,
+		Title:       "Tilepack archive generation",
+		Description: "Generate a canonical or custom PMTiles or MBTiles archive for a single OAM STAC item using the existing tilepack worker, S3 output path, and pgSTAC publication flow.",
+		Version:     "1.0.0",
+		JobControlOptions: []string{"async-execute"},
+		OutputTransmission: []string{"reference"},
+		Keywords:    []string{"tilepack", "pmtiles", "mbtiles", "stac", "openaerialmap"},
+		Inputs: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"id": map[string]any{"type": "string", "description": "STAC item id in the openaerialmap collection"},
+				"format": map[string]any{"type": "string", "enum": []string{"pmtiles", "mbtiles"}},
+				"min_zoom": map[string]any{"type": "integer", "minimum": 0, "maximum": 24},
+				"max_zoom": map[string]any{"type": "integer", "minimum": 0, "maximum": 24},
+			},
+			"required": []string{"id", "format"},
+		},
+		Outputs: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"status": map[string]any{"type": "string", "description": "accepted, in_progress, ready, or error"},
+				"url": map[string]any{"type": "string", "description": "Public S3 URL for a ready archive"},
+				"message": map[string]any{"type": "string"},
+			},
+		},
+		Links: []map[string]any{{
+			"rel": "self",
+			"type": "application/json",
+			"href": "/processes/tilepack",
+		}, {
+			"rel": "execution",
+			"type": "application/json",
+			"href": "/processes/tilepack/execution",
+		}},
+	}
+}
+
 // postTilepack starts or polls tilepack generation for one STAC item.
 //
 // Endpoint:
@@ -172,11 +318,15 @@ type response struct {
 //   - 202 {"status":"started"} or {"status":"in_progress"}
 //   - 200 {"status":"ready","url":"https://..."}
 func (h *Handler) postTilepack(w http.ResponseWriter, r *http.Request) {
-	started := time.Now()
 	id := r.PathValue("id")
 	format := strings.ToLower(r.URL.Query().Get("format"))
 	minZoomQ := r.URL.Query().Get("min_zoom")
 	maxZoomQ := r.URL.Query().Get("max_zoom")
+	h.handleTilepackRequest(w, r, id, format, minZoomQ, maxZoomQ)
+}
+
+func (h *Handler) handleTilepackRequest(w http.ResponseWriter, r *http.Request, id, format, minZoomQ, maxZoomQ string) {
+	started := time.Now()
 	ip := clientIP(r)
 	zoomMode := "custom"
 	if minZoomQ == "" && maxZoomQ == "" {

--- a/backend/tilepack-api/internal/handler/handler_test.go
+++ b/backend/tilepack-api/internal/handler/handler_test.go
@@ -377,6 +377,98 @@ func TestPostTilepack_EarlyValidationPaths(t *testing.T) {
 	}
 }
 
+func TestProcessDiscoveryRoutes(t *testing.T) {
+	h := &Handler{}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/processes", nil)
+	h.Routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /processes status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	var list struct {
+		Processes []map[string]any `json:"processes"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&list); err != nil {
+		t.Fatalf("decode /processes: %v", err)
+	}
+	if len(list.Processes) == 0 {
+		t.Fatal("GET /processes returned no processes")
+	}
+	if got := list.Processes[0]["id"]; got != "tilepack" {
+		t.Fatalf("first process id = %#v, want %q", got, "tilepack")
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/processes/tilepack", nil)
+	h.Routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /processes/tilepack status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	var proc map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&proc); err != nil {
+		t.Fatalf("decode /processes/tilepack: %v", err)
+	}
+	if proc["id"] != "tilepack" {
+		t.Fatalf("process id = %#v, want %q", proc["id"], "tilepack")
+	}
+	if proc["title"] == "" {
+		t.Fatal("process title is empty")
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/processes/unknown", nil)
+	h.Routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("GET /processes/unknown status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestProcessExecutionValidationUsesTilepackRules(t *testing.T) {
+	h := &Handler{}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/processes/tilepack/execution?id=valid_id-123&format=zip", nil)
+	h.Routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+	var resp response
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Message != "format must be pmtiles or mbtiles" {
+		t.Fatalf("message = %q, want %q", resp.Message, "format must be pmtiles or mbtiles")
+	}
+}
+
+func TestParseProcessExecutionInputs_RejectsMalformedJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/processes/tilepack/execution?format=pmtiles", strings.NewReader("{\"id\":\"abc"))
+	_, _, _, _, err := parseProcessExecutionInputs(req)
+	if err == nil {
+		t.Fatal("parseProcessExecutionInputs() expected malformed JSON error")
+	}
+	if got, want := err.Error(), "invalid JSON body"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
+func TestParseProcessExecutionInputs_UsesCanonicalInputsObject(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/processes/tilepack/execution", strings.NewReader(`{"inputs":{"id":"valid_id-123","format":"pmtiles","min_zoom":"3","max_zoom":"8"}}`))
+	id, format, minZoomQ, maxZoomQ, err := parseProcessExecutionInputs(req)
+	if err != nil {
+		t.Fatalf("parseProcessExecutionInputs() unexpected error: %v", err)
+	}
+	if id != "valid_id-123" {
+		t.Fatalf("id = %q, want %q", id, "valid_id-123")
+	}
+	if format != "pmtiles" {
+		t.Fatalf("format = %q, want %q", format, "pmtiles")
+	}
+	if minZoomQ != "3" || maxZoomQ != "8" {
+		t.Fatalf("zoom values = (%q, %q), want (%q, %q)", minZoomQ, maxZoomQ, "3", "8")
+	}
+}
+
 func TestClientIP(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🍕 Feature
* [ ] 🐛 Bug Fix
* [ ] 📝 Documentation
* [ ] 🧑‍💻 Refactor
* [x] ✅ Test
* [ ] 🤖 Build or CI
* [ ] ❓ Other (please specify)

## Related Issue

Fixes #302

## Describe this PR

This PR adds a minimal OGC-compatible process discovery and execution surface for the existing tilepack workflow.

It introduces:

* `GET /processes` to discover available processes
* `GET /processes/tilepack` to describe the tilepack process
* `POST /processes/tilepack/execution` to trigger the existing tilepack workflow

The new process API is implemented as a thin adapter over the existing tilepack execution path. It reuses the current validation, S3 idempotency/output handling, Kubernetes Job creation, and pgSTAC publication flow rather than introducing a separate execution framework or database.

The tilepack ingress is also updated to expose the new `/processes` routes.

This is intentionally a first-pass implementation focused on establishing the process API convention with one existing OAM workflow. Cross-service `/processes` routing, a global process registry, additional processing workflows, and a separate `/jobs/{jobId}` API are left for future work.

## Screenshots

Not applicable. This PR adds backend API endpoints and deployment configuration without UI changes.

## Alternative Approaches Considered

The issue discussion considered using ZOO-Project to provide the OGC Processes API and introducing a broader workflow/process layer.

For this first pass, I chose to keep the implementation within the existing tilepack service and adapt the current tilepack execution flow instead.

This avoids introducing a new execution framework or database before validating the API convention against a real OAM processing workflow.

A broader `/processes` registry or multi-service routing strategy can be addressed separately once the first process implementation has been reviewed.

## Review Guide

The main areas to review are:

1. Process discovery:

   * `GET /processes`
   * `GET /processes/tilepack`
   * `GET /processes/unknown` → `404`

2. Process execution:

   * `POST /processes/tilepack/execution`
   * Verify canonical `{"inputs": {...}}` request handling
   * Verify invalid JSON and invalid inputs are rejected

3. Backward compatibility:

   * Existing `POST /tilepacks/{id}` behavior remains unchanged
   * The new execution endpoint delegates to the same tilepack execution logic

4. Deployment:

   * Review the tilepack ingress routing for `/processes`

5. Tests:

   * `go test ./...`
   * `go vet ./...`

The implementation intentionally does not add a separate job registry; the existing tilepack execution/status behavior remains the source of truth for this first pass.

## Checklist before requesting a review

* 📖 Read the OAM Contributing Guide: https://github.com/hotosm/openaerialmap/blob/main/CONTRIBUTING.md
* 📖 Read the HOT Code of Conduct: https://docs.hotosm.org/code-of-conduct
* 👷‍♀️ Create small PRs. In most cases, this will be possible.
* ✅ Provide tests for your changes.
* 📝 Use descriptive commit messages.
* 📗 Update any related documentation and include any relevant screenshots.